### PR TITLE
20250225 pxp sync fix 4

### DIFF
--- a/ModernPatternEditor/ModernPatternEditor.NET/PatternEditor.xaml.cs
+++ b/ModernPatternEditor/ModernPatternEditor.NET/PatternEditor.xaml.cs
@@ -111,17 +111,17 @@ namespace WDE.ModernPatternEditor
             PropertyChanged.Raise(this, "ChangeMachine");
         }
 
-        private void Song_SequenceChanged(int obj)
+        private void Song_SequenceChanged(int obj, ISequence seq)
         {
             playRecordManager.RefreshPlayPosData();
         }
 
-        private void Song_SequenceRemoved(int obj)
+        private void Song_SequenceRemoved(int obj, ISequence seq)
         {
             playRecordManager.RefreshPlayPosData();
         }
 
-        private void Song_SequenceAdded(int obj)
+        private void Song_SequenceAdded(int obj, ISequence seq)
         {
             playRecordManager.RefreshPlayPosData();
         }

--- a/NativeMachineFramework/MachineEventWrapper.cpp
+++ b/NativeMachineFramework/MachineEventWrapper.cpp
@@ -17,7 +17,7 @@ namespace ReBuzz
         {
             m_callbacks = new std::vector<EVENT_HANDLER_PTR>();
             m_callbackParams = new std::vector<void*>();
-            m_selfId = Utils::ObjectToInt64(self);
+            m_selfId = self->CMachinePtr.ToInt64();
         }
 
         MachineEventWrapper::!MachineEventWrapper()
@@ -56,7 +56,7 @@ namespace ReBuzz
                 return;
 
             //Is this us?
-            int64_t machineId = Utils::ObjectToInt64(machine);
+            int64_t machineId = machine->CMachinePtr.ToInt64();
             if (machineId == m_selfId)
                 return;
 

--- a/NativeMachineFramework/MachineManager.cpp
+++ b/NativeMachineFramework/MachineManager.cpp
@@ -264,7 +264,7 @@ namespace ReBuzz
                 machdata->m_info.Parameters = machdata->parameterPtrs.data();
 
             //Store the internal id against the machine name
-            int64_t id = Utils::ObjectToInt64(rebuzzMach);
+            int64_t id = rebuzzMach->CMachinePtr.ToInt64();
             machCallbackData->machineNameMap[machdata->name] = id;
         }
 
@@ -384,7 +384,7 @@ namespace ReBuzz
             {
                 std::lock_guard<std::mutex> lg(*m_lock);
 
-                machid = Utils::ObjectToInt64(m);
+                machid = m->CMachinePtr.ToInt64();
                 pmach = m_machineMap->GetOrStoreReBuzzTypeById(machid, m, &itemCreated);
             }
 
@@ -401,7 +401,7 @@ namespace ReBuzz
         {
             std::lock_guard<std::mutex> lg(*m_lock);
 
-            int64_t machid = Utils::ObjectToInt64(m);
+            int64_t machid = m->CMachinePtr.ToInt64();
             return m_machineMap->GetBuzzTypeById(machid);
         }
 
@@ -431,7 +431,7 @@ namespace ReBuzz
                             if (mach->Name == clrName)
                             {
                                 //Found - create entry in our map
-                                machid = Utils::ObjectToInt64(mach);
+                                machid = mach->CMachinePtr.ToInt64();
                                 rebuzzMachine = mach;
                                 ret = machCallbackData->machineMap->GetOrStoreReBuzzTypeById(machid, mach, &itemCreated);
                                 machCallbackData->machineNameMap[name] = machid;
@@ -470,7 +470,7 @@ namespace ReBuzz
                 std::lock_guard<std::mutex> lg(*m_lock);
 
                 //Do we have this machine in our map?
-                id = Utils::ObjectToInt64(machine);
+                id = machine->CMachinePtr.ToInt64();
                 pmach = m_machineMap->GetBuzzTypeById(id);
                 if (pmach == NULL)
                 {
@@ -491,7 +491,7 @@ namespace ReBuzz
             //Call the removed callback first
             if (m_onMachineRemovedCallback != nullptr)
             {
-                int64_t id = Utils::ObjectToInt64(machine);
+                int64_t id = machine->CMachinePtr.ToInt64();
                 CMachine* buzzMachine = NULL;
                 {
                     std::lock_guard<std::mutex> lg(*m_lock);
@@ -505,7 +505,7 @@ namespace ReBuzz
             std::lock_guard<std::mutex> lg(*m_lock);
 
             //Remove from machine manager
-            int64_t id = Utils::ObjectToInt64(machine);
+            int64_t id = machine->CMachinePtr.ToInt64();
             if (m_machineMap != NULL)
                 m_machineMap->RemoveById(id);
             

--- a/NativeMachineFramework/MachineWrapper.cpp
+++ b/NativeMachineFramework/MachineWrapper.cpp
@@ -22,6 +22,7 @@ using BuzzGUI::Interfaces::MachineType;
 using BuzzGUI::Interfaces::MachineInfoFlags;
 using BuzzGUI::Interfaces::ParameterType;
 using BuzzGUI::Interfaces::ParameterFlags;
+using BuzzGUI::Interfaces::PatternEvent;
 
 namespace ReBuzz
 {
@@ -65,12 +66,12 @@ namespace ReBuzz
         
         
 
-        void MachineWrapper::OnSequenceCreatedByReBuzz(int seq)
+        void MachineWrapper::OnSequenceCreatedByReBuzz(int idx, ISequence^ seq)
         {
 
         }
 
-        void MachineWrapper::OnSequecneRemovedByReBuzz(int seq)
+        void MachineWrapper::OnSequecneRemovedByReBuzz(int idx, ISequence^ seq)
         {
 
         }
@@ -114,7 +115,9 @@ namespace ReBuzz
                                                                 m_onKeyupHandler(nullptr),
                                                                 m_editorMessageMap(new std::unordered_map<UINT, OnWindowsMessage>()),
                                                                 m_editorMessageParamMap(new std::unordered_map<UINT, void*>()),
-                                                                m_onSelectedWaveChange(gcnew System::Collections::Generic::List<OnSelectedWaveChange^>())
+                                                                m_onSelectedWaveChange(gcnew System::Collections::Generic::List<OnSelectedWaveChange^>()),
+                                                                m_patternPosTickMap(new std::unordered_map<int64_t, int>()),
+                                                                m_lock(new std::mutex())
         {
             
             //Create machine manager
@@ -131,7 +134,17 @@ namespace ReBuzz
             m_onPatternAddedCallback = gcnew PatternManager::OnPatternEventDelegate(this, &MachineWrapper::OnPatternAdded);
             m_onPatternRemovedCallback = gcnew PatternManager::OnPatternEventDelegate(this, &MachineWrapper::OnPatternRemoved);
             m_onPatternChangedCallback = gcnew PatternManager::OnPatternEventDelegate(this, &MachineWrapper::OnPatternChanged);
-            m_patternMgr = gcnew PatternManager(m_onPatternAddedCallback, m_onPatternRemovedCallback, m_onPatternChangedCallback, nullptr);
+            m_onPatternPlayStartCallback = gcnew PatternManager::OnPatternPlayDelegate(this, &MachineWrapper::OnPatternPlayStart);
+            m_onPatternPlayEndCallback = gcnew PatternManager::OnPatternPlayDelegate(this, &MachineWrapper::OnPatternPlayEnd);
+            m_onPatternPlayPosChangeCallback = gcnew PatternManager::OnPatternPlayDelegate(this, &MachineWrapper::OnPatternPlayPosChange);
+            
+            m_patternMgr = gcnew PatternManager(m_onPatternAddedCallback, 
+                                                m_onPatternRemovedCallback, 
+                                                m_onPatternChangedCallback, 
+                                                nullptr,
+                                                m_onPatternPlayStartCallback,
+                                                m_onPatternPlayEndCallback,
+                                                m_onPatternPlayPosChangeCallback);
             
             //Create Wave manager
             m_waveManager = gcnew WaveManager();
@@ -149,11 +162,11 @@ namespace ReBuzz
             m_masterInfo = new CMasterInfo();
 
             //Ask ReBuzz to tell us when a sequence has been added
-            m_seqAddedAction = gcnew System::Action<int>(this, &MachineWrapper::OnSequenceCreatedByReBuzz);
+            m_seqAddedAction = gcnew System::Action<int, ISequence^>(this, &MachineWrapper::OnSequenceCreatedByReBuzz);
             Global::Buzz->Song->SequenceAdded += m_seqAddedAction;
 
             //Ask ReBuzz to tell us when a sequence has been removed
-            m_seqRemovedAction = gcnew System::Action<int>(this, &MachineWrapper::OnSequecneRemovedByReBuzz);
+            m_seqRemovedAction = gcnew System::Action<int, ISequence^>(this, &MachineWrapper::OnSequecneRemovedByReBuzz);
             Global::Buzz->Song->SequenceRemoved += m_seqRemovedAction;
 
             //Set up action for buzz song property changed (allows us to detect song stopped)
@@ -184,8 +197,6 @@ namespace ReBuzz
                 m_callbackWrapper = NULL;
             }
 
-         
-
             if (m_sequenceMap != NULL)
             {
                 delete m_sequenceMap;
@@ -203,6 +214,18 @@ namespace ReBuzz
             {
                 delete m_onSelectedWaveChange;
                 m_onSelectedWaveChange = nullptr;   
+            }
+
+            if (m_patternPosTickMap != NULL)
+            {
+                delete m_patternPosTickMap; 
+                m_patternPosTickMap = NULL;
+            }
+
+            if (m_lock != NULL)
+            {
+                delete m_lock;
+                m_lock = NULL;
             }
         }
 
@@ -315,6 +338,24 @@ namespace ReBuzz
                 m_patternMgr = nullptr;
             }
 
+            if (m_onPatternPlayEndCallback != nullptr)
+            {
+                delete m_onPatternPlayEndCallback;
+                m_onPatternPlayEndCallback = nullptr;
+            }
+
+            if (m_onPatternPlayStartCallback != nullptr)
+            {
+                delete m_onPatternPlayStartCallback;
+                m_onPatternPlayStartCallback = nullptr;
+            }
+
+            if (m_onPatternPlayPosChangeCallback != nullptr)
+            {
+                delete m_onPatternPlayPosChangeCallback;
+                m_onPatternPlayPosChangeCallback = nullptr;
+            }
+
             if (m_onPatEditorRedrawCallbacks != nullptr)
             {
                 delete m_onPatEditorRedrawCallbacks;
@@ -409,17 +450,51 @@ namespace ReBuzz
 
         void MachineWrapper::Tick()
         {
+            if (!m_initialised || (m_machine == NULL) || (m_host == nullptr))
+                return;
+
             //Update master info
             //This copies the master info from ReBuzz into the
             //CMasterInfo pointer attached to the native machine
             UpdateMasterInfo();
 
-            //Call tick on machine on the stroke of every tick
-            if (m_initialised && (m_machine != NULL) && m_masterInfo->PosInTick == 0)
+            if (m_host->SubTickInfo->CurrentSubTick != 0)
             {
-                //Tell the machine to tick
-                m_machine->Tick();
+                return;
             }
+            
+            //Gather list of playing patterns
+            //The m_patternPosTickMap list is updated when a pattern is played, the play position updated, or 
+            //a pattern is stopped.  The last position that NotifyOfPlayingPattern was called for the pattern
+            //is recorded, to prevent multiple calls for the same position (subticks, etc)
+            List<IPattern^> patternsToNotify;
+            {
+                std::lock_guard<std::mutex> lg(*m_lock);
+                for (auto& playingpat : *m_patternPosTickMap)
+                {
+                    IPattern^ pat =  m_patternMgr->GetById(playingpat.first, NULL);
+                    if (pat != nullptr)
+                    {   
+                        int newPlayPos = pat->PlayPosition / PatternEvent::TimeBase;
+                        if (playingpat.second != newPlayPos)
+                        {
+                            patternsToNotify.Add(pat);
+                            playingpat.second = newPlayPos;
+                        }
+                    }
+                }
+            }
+
+
+            //Notify of patterns playing (outside the lock)
+            for each(IPattern^ p in patternsToNotify)
+            {
+                NotifyOfPlayingPattern(p);
+            }
+            
+            
+            //Tell the machine to tick
+            m_machine->Tick();
         }
 
         void MachineWrapper::SetModifiedFlag()
@@ -835,7 +910,7 @@ namespace ReBuzz
             //Set target machine if needed            
             if ((currentEditorTgtMach != patMach) && (m_onNewPatternCallbacks != nullptr))
             {
-                int64_t patid = Utils::ObjectToInt64(pattern);
+                int64_t patid = pattern->CPattern.ToInt64();
                 for each (OnNewPatternDelegate ^ onNewPatCallback in m_onNewPatternCallbacks)
                 {
                     try
@@ -906,54 +981,31 @@ namespace ReBuzz
             exInterface->CreatePatternCopy(newPat, oldPat);
         }
 
-        void MachineWrapper::NotifyOfPlayingPattern()
+        void MachineWrapper::NotifyOfPlayingPattern(IPattern^ pat)
         {
             CMachineInterfaceEx* exInterface = m_callbackWrapper->GetExInterface();
+            if (exInterface == NULL)
+                return;
 
-            //Get sequences and tell machine about them
-            for each (ISequence ^ s in Global::Buzz->Song->Sequences)
+            CPattern* cpat = m_patternMgr->GetOrStorePattern(pat);
+            if((cpat != NULL) &&  (pat->PlayPosition > int::MinValue))
             {
-                if (!s->IsDisabled)
+                //Query the pattern for associated sequence(s)
+                for each (ISequence ^ s in pat->Sequences)
                 {
-                    //Ignore any sequence that does not have a playing sequence
-                    IPattern^ playingPat = s->PlayingPattern;
-                    if ((playingPat != nullptr) && (playingPat->PlayPosition >= 0))
+                    //Only notify of pattern playing if the machine associated with the current sequence 
+                    //matches the machine associated with the pattern
+                    if (!s->IsDisabled &&  (s->Machine == pat->Machine))
                     {
-                        //Get CPattern * for this pattern
-                        CPattern* cpat = m_patternMgr->GetOrStorePattern(playingPat);
-                        if (cpat != NULL)
+                        int64_t seqid = s->CSequence.ToInt64();
+                        bool created = false;
+                        CSequence* cseq = m_sequenceMap->GetOrStoreReBuzzTypeById(seqid, s, &created);
+                        if (cseq != NULL)
                         {
-                            CPatternData* patdata = m_patternMgr->GetBuzzPatternData(cpat);
-
-                            //Get CSequence * for this sequence
-                            uint64_t seqid = s->GetHashCode();
-                            bool created = false;
-                            CSequence* cseq = m_sequenceMap->GetOrStoreReBuzzTypeById(seqid, s, &created);
-                            if (cseq != NULL)
-                            {
-                                CMachine* patMach = m_machineMgr->GetOrStoreMachine(playingPat->Machine);
-
-                                //Ask the Native machine if it's ok to call the exInterface
-                                bool callExInterface = true;
-                                if (m_onPlayPatternCallbacks != nullptr)
-                                {
-                                    for each (OnPatternPlayDelegate ^ playPatCallback in m_onPlayPatternCallbacks)
-                                    {
-                                        if (!playPatCallback(playingPat->Machine, patMach, playingPat, cpat, playingPat->Name))
-                                        {
-                                            callExInterface = false;
-                                        }
-                                    }
-                                }
-
-                                if (callExInterface && (exInterface != NULL))
-                                {
-                                    //Tell interface about this pattern and the current play position within
-                                    //that pattern.
-                                    int playpos = s->PlayingPatternPosition;
-                                    exInterface->PlayPattern(cpat, cseq, playpos);
-                                }
-                            }
+                            //Tell interface about this pattern and the current play position within
+                            //that pattern.
+                            int playpos = pat->PlayPosition / PatternEvent::TimeBase;
+                            exInterface->PlayPattern(cpat, cseq, playpos);
                         }
                     }
                 }
@@ -1004,7 +1056,7 @@ namespace ReBuzz
         cli::array<int>^ MachineWrapper::GetPatternEditorMachineMIDIEvents(IPattern^ pattern)
         {
             //Get pattern
-            uint64_t patid = pattern->GetHashCode();
+            int64_t patid = pattern->CPattern.ToInt64(); 
             CPattern* pat = m_patternMgr->GetOrStorePattern(pattern);
 
             //Save data 
@@ -1128,6 +1180,41 @@ namespace ReBuzz
                     }
                 }
             }
+        }
+
+        void MachineWrapper::OnPatternPlayStart(int64_t id, IPattern^ rebuzzPat, CPattern* buzzPat)
+        {
+            int newPlayPos = rebuzzPat->PlayPosition / PatternEvent::TimeBase;
+
+            {
+                std::lock_guard<std::mutex> lg(*m_lock);
+                (*m_patternPosTickMap)[id] = -1;
+            }
+        }
+
+        void MachineWrapper::OnPatternPlayEnd(int64_t id, IPattern^ rebuzzPat, CPattern* buzzPat)
+        {
+            std::lock_guard<std::mutex> lg(*m_lock);
+            m_patternPosTickMap->erase(id);
+        }
+        
+        void MachineWrapper::OnPatternPlayPosChange(int64_t id, IPattern^ rebuzzPat, CPattern* buzzPat)
+        {
+            int newPlayPos = rebuzzPat->PlayPosition / PatternEvent::TimeBase;
+            bool notify = false;
+            {
+                std::lock_guard<std::mutex> lg(*m_lock);
+                
+                auto  found = m_patternPosTickMap->find(id);
+                if ((found == m_patternPosTickMap->end()) || ((*found).second != newPlayPos))
+                {
+                    notify = true;
+                    (*m_patternPosTickMap)[id] = rebuzzPat->PlayPosition / PatternEvent::TimeBase;
+                }
+            }
+
+            if(notify)
+                NotifyOfPlayingPattern(rebuzzPat);
         }
 
 
@@ -1268,17 +1355,9 @@ namespace ReBuzz
             }
         }
 
-        
-        
-
-        
-        
-        
-        
-
         CSequence* MachineWrapper::GetSequence(ISequence^ seq)
         {
-            uint64_t id = seq->GetHashCode();
+            uint64_t id = seq->CSequence.ToInt64();
             bool created = false;
             return m_sequenceMap->GetOrStoreReBuzzTypeById(id, seq, &created);
         }

--- a/NativeMachineFramework/MachineWrapper.cpp
+++ b/NativeMachineFramework/MachineWrapper.cpp
@@ -128,7 +128,6 @@ namespace ReBuzz
             //Create pattern manager
             m_onPatEditorRedrawCallbacks = gcnew List<OnPatternEditorRedrawDelegate^>();
             m_onNewPatternCallbacks = gcnew List<OnNewPatternDelegate^>();
-            m_onPlayPatternCallbacks = gcnew List< OnPatternPlayDelegate^>();
             m_kbFocusWindowHandleCallbacks = gcnew List<KeyboardFocusWindowHandleDelegate^>();
             m_onPatternEditorCreatedCallbacks = gcnew List<OnPatternEditorCreatedDelegate^>();
             m_onPatternAddedCallback = gcnew PatternManager::OnPatternEventDelegate(this, &MachineWrapper::OnPatternAdded);
@@ -374,12 +373,6 @@ namespace ReBuzz
                 m_onPatternEditorCreatedCallbacks = nullptr;
             }
 
-            if (m_onPlayPatternCallbacks != nullptr)
-            {
-                delete  m_onPlayPatternCallbacks;
-                m_onPlayPatternCallbacks = nullptr;
-            }
-
             if (m_kbFocusWindowHandleCallbacks != nullptr)
             {
                 delete m_kbFocusWindowHandleCallbacks;
@@ -476,7 +469,7 @@ namespace ReBuzz
                     if (pat != nullptr)
                     {   
                         int newPlayPos = pat->PlayPosition / PatternEvent::TimeBase;
-                        if (playingpat.second != newPlayPos)
+                        if ((newPlayPos > int::MinValue) &&  (playingpat.second != newPlayPos))
                         {
                             patternsToNotify.Add(pat);
                             playingpat.second = newPlayPos;
@@ -865,24 +858,6 @@ namespace ReBuzz
             }
         }
 
-
-        void MachineWrapper::AddPatternPlayCallback(OnPatternPlayDelegate^ callback)
-        {
-            if (m_onPlayPatternCallbacks != nullptr)
-            {
-                m_onPlayPatternCallbacks->Add(callback);
-            }
-        }
-
-        void MachineWrapper::RemovePatternPlayCallback(OnPatternPlayDelegate^ callback)
-        {
-            if (m_onPlayPatternCallbacks != nullptr)
-            {
-                m_onPlayPatternCallbacks->Remove(callback);
-            }
-        }
-
-
         void MachineWrapper::SetEditorPattern(IPattern^ pattern)
         {
             //Make sure we're initialised
@@ -995,7 +970,7 @@ namespace ReBuzz
                 {
                     //Only notify of pattern playing if the machine associated with the current sequence 
                     //matches the machine associated with the pattern
-                    if (!s->IsDisabled &&  (s->Machine == pat->Machine))
+                    if (!s->IsDisabled && (pat == s->PlayingPattern) &&  (s->Machine == pat->Machine))
                     {
                         int64_t seqid = s->CSequence.ToInt64();
                         bool created = false;

--- a/NativeMachineFramework/MachineWrapper.h
+++ b/NativeMachineFramework/MachineWrapper.h
@@ -141,8 +141,6 @@ namespace ReBuzz
 
             void CreatePatternCopy(IPattern^ pnew, IPattern^ p);
 
-            void NotifyOfPlayingPattern();
-
             void OverridePatternEditorWindowsMessage(UINT msg, IntPtr callback, void* param);
 
             void AddPatternEditorKeyboardFocusCallback(KeyboardFocusWindowHandleDelegate^ callback);
@@ -195,6 +193,10 @@ namespace ReBuzz
             void OnPatternAdded(int64_t id, IPattern^ pat, CPattern* buzzPat, PatternEventFlags flags);
             void OnPatternRemoved(int64_t id, IPattern^ pat, CPattern* buzzPat, PatternEventFlags flags);
             void OnPatternChanged(int64_t id, IPattern^ pat, CPattern* buzzPat, PatternEventFlags flags);
+            void OnPatternPlayStart(int64_t id, IPattern^ rebuzzPat, CPattern* buzzPat);
+            void OnPatternPlayEnd(int64_t id, IPattern^ rebuzzPat, CPattern* buzzPat);
+            void OnPatternPlayPosChange(int64_t id, IPattern^ rebuzzPat, CPattern* buzzPat);
+
 
             void SendMessageToKeyboardWindow(UINT msg, WPARAM wparam, LPARAM lparam);
 
@@ -208,11 +210,12 @@ namespace ReBuzz
             
             void Free();
 
-            void OnSequenceCreatedByReBuzz(int seq);
-            void OnSequecneRemovedByReBuzz(int seq);
+            void OnSequenceCreatedByReBuzz(int idx, ISequence^ seq);
+            void OnSequecneRemovedByReBuzz(int idx, ISequence^ seq);
 
             void BuzzSong_PropertyChanged(System::Object^ sender, PropertyChangedEventArgs^ args);
             
+            void NotifyOfPlayingPattern(IPattern ^ pat);
 
             
             RebuzzBuzzLookup<ISequence, int, CSequence>* m_sequenceMap;
@@ -236,6 +239,9 @@ namespace ReBuzz
             PatternManager::OnPatternEventDelegate^ m_onPatternAddedCallback;
             PatternManager::OnPatternEventDelegate^ m_onPatternRemovedCallback;
             PatternManager::OnPatternEventDelegate^ m_onPatternChangedCallback;
+            PatternManager::OnPatternPlayDelegate^ m_onPatternPlayStartCallback;
+            PatternManager::OnPatternPlayDelegate^ m_onPatternPlayEndCallback;
+            PatternManager::OnPatternPlayDelegate^ m_onPatternPlayPosChangeCallback;
 
 
 
@@ -257,16 +263,18 @@ namespace ReBuzz
             CMachine* m_patternEditorMachine;
 
            
-            System::Action<int>^ m_seqAddedAction;
-            System::Action<int>^ m_seqRemovedAction;
+            System::Action<int,ISequence^>^ m_seqAddedAction;
+            System::Action<int, ISequence^>^ m_seqRemovedAction;
             UserControl^ m_control;
 
+            
             KeyEventHandler^ m_onKeyDownHandler;
             KeyEventHandler^ m_onKeyupHandler;
             std::unordered_map<UINT, OnWindowsMessage> * m_editorMessageMap;
             std::unordered_map<UINT, void *> * m_editorMessageParamMap;
             PropertyChangedEventHandler^ m_buzzSongPropChangeHandler;
-            
+            std::unordered_map<int64_t, int> * m_patternPosTickMap;
+            std::mutex* m_lock;
         };
     }
 }

--- a/NativeMachineFramework/MachineWrapper.h
+++ b/NativeMachineFramework/MachineWrapper.h
@@ -96,8 +96,6 @@ namespace ReBuzz
              delegate void OnNewPatternDelegate(IMachine^ rebuzzMachine, void * buzzMachine, 
                                                IPattern^ rebuzzPattern, void * buzzPattern,String^ patternName);
 
-            delegate bool OnPatternPlayDelegate(IMachine^ rebuzzMachine, void * buzzMachine,
-                                                IPattern^ rebuzzPattern, void * buzzPattern,String^ patternName);
 
             delegate void OnPatternEditorRedrawDelegate();
 
@@ -130,10 +128,6 @@ namespace ReBuzz
             void AddPatternEditorCreaetdCallback(OnPatternEditorCreatedDelegate^ callback);
 
             void RemovePatternEditorCreaetdCallback(OnPatternEditorCreatedDelegate^ callback);
-
-            void AddPatternPlayCallback(OnPatternPlayDelegate^ callback);
-
-            void RemovePatternPlayCallback(OnPatternPlayDelegate^ callback);
 
             void SetEditorPattern(IPattern^ pattern);
 
@@ -229,7 +223,6 @@ namespace ReBuzz
             System::Collections::Generic::List< OnPatternEditorRedrawDelegate^>^ m_onPatEditorRedrawCallbacks;
             System::Collections::Generic::List< OnPatternEditorCreatedDelegate^>^ m_onPatternEditorCreatedCallbacks;
             System::Collections::Generic::List< OnNewPatternDelegate^>^ m_onNewPatternCallbacks;
-            System::Collections::Generic::List< OnPatternPlayDelegate^>^ m_onPlayPatternCallbacks;
             System::Collections::Generic::List < KeyboardFocusWindowHandleDelegate^>^ m_kbFocusWindowHandleCallbacks;
 
             WaveManager^ m_waveManager;

--- a/NativeMachineFramework/PatternManager.h
+++ b/NativeMachineFramework/PatternManager.h
@@ -39,10 +39,15 @@ namespace ReBuzz
 
             delegate void OnPatternEditorRedrawDelegate();
 
+            delegate void OnPatternPlayDelegate(int64_t id, IPattern^ pat, CPattern* buzzPat);
+
             PatternManager(OnPatternEventDelegate^ onPatternAddedCallback,
                            OnPatternEventDelegate^ onPatternRemovedCallback,
                            OnPatternEventDelegate^ onPatternChangedCallback,
-                           OnPatternEditorRedrawDelegate^ onPatternEditorRedrawCallback);
+                           OnPatternEditorRedrawDelegate^ onPatternEditorRedrawCallback, 
+                           OnPatternPlayDelegate^ onPatternPlayStartCallback,
+                           OnPatternPlayDelegate^ onPatternPlayEndCallback, 
+                           OnPatternPlayDelegate^ onPatternPlayPosChangeCallback);
 
             !PatternManager();
             ~PatternManager();
@@ -58,6 +63,8 @@ namespace ReBuzz
             IPattern^ GetReBuzzPattern(CPattern * pat);
 
             CPatternData* GetBuzzPatternData(CPattern * pat);
+
+            IPattern^ GetById(int64_t id, CPattern** retbuzzpat);
 
             void OnNativePatternChange(CPattern* pat, int newLen, const char * newName );
 
@@ -76,6 +83,10 @@ namespace ReBuzz
             void OnPatternCreatedByRebuzz(IPattern^ pattern);
             void OnPatternRemovedByRebuzz(IPattern^ pattern);
             
+            void OnPatternPlayStart(IPattern^ pattern);
+            void OnPatternPlayPosChange(IPattern^ pattern);
+            void OnPatternPlayEnd(IPattern^ pattern);
+
             static void PatternChangeCheckCallback(uint64_t id, IPattern^ rebuzzpat, CPattern* buzzpat, CPatternData* patdata, void* param);
 
 
@@ -89,12 +100,20 @@ namespace ReBuzz
             OnPatternEventDelegate^ m_onPatternRemovedCallback;
             OnPatternEventDelegate^ m_onPatternChangedCallback;
             OnPatternEditorRedrawDelegate^ m_onPatternEditorRedrawCallback;
+            OnPatternPlayDelegate^ m_onPatternPlayStartCallback;
+            OnPatternPlayDelegate^ m_onPatternPlayEndCallback;
+            OnPatternPlayDelegate^ m_onPatternPlayPosChangeCallback;
             
             System::Action<IPatternColumn^>^ m_onPatternChangeAction;
             PropertyChangedEventHandler^ m_onPropChangeEventHandler;
 
             System::Action<IPattern^>^ m_patternAddedAction;
             System::Action<IPattern^>^ m_patternRemovedAction;
+            System::Action<IPattern^>^ m_patternPlayStartAction;
+            System::Action<IPattern^>^ m_patternPlayEndAction;
+            System::Action<IPattern^>^ m_patternPlayPosChangeAction;
+
+
             std::set<int64_t>* m_eventHandlersAddedToMachines;
             std::vector<RefClassWrapper<IMachine>> * m_machinesEventHandlersAddedTo;
             IMachine^ m_editorTargetMachine;

--- a/NativeMachineFramework/RebuzzBuzzLookup.h
+++ b/NativeMachineFramework/RebuzzBuzzLookup.h
@@ -140,6 +140,8 @@ namespace ReBuzz
             BuzzType* GetBuzzTypeById_Internal(uint64_t id) const
             {
                 BuzzType* ret = NULL;
+                if (id == 0)
+                    return NULL;
 
                 const auto& found = m_idToDataMap.find(id);
                 if (found == m_idToDataMap.end())

--- a/ReBuzz/Core/PatternCore.cs
+++ b/ReBuzz/Core/PatternCore.cs
@@ -215,16 +215,27 @@ namespace ReBuzz.Core
         {
             Global.Buzz.Song.SequenceAdded -= Song_SequenceAdded;
             Global.Buzz.Song.SequenceRemoved -= Song_SequenceRemoved;
-            Global.Buzz.Song.SequenceChanged -= Song_SequenceAdded;
+            Global.Buzz.Song.SequenceChanged -= Song_SequenceChanged;
         }
 
+        
         private void Song_SequenceAdded(int obj, ISequence seq)
+        {
+            lock (_owningSequences)
+            {   //If the added sequence refers to the same machine as the
+                //one associated with the pattern, then associate the sequence with this pattern.
+                if(seq.Machine == Machine)
+                    _owningSequences.Add((ISequence)seq);
+            }
+        }
+
+        private void Song_SequenceChanged(int obj, ISequence seq)
         {
             lock (_owningSequences)
             {
                 //If the added sequence refers to the same machine as the
                 //one associated with the pattern, then associate the sequence with this pattern.
-                if(seq.Machine == Machine)
+                if (seq.Machine == Machine)
                     _owningSequences.Add((ISequence)seq);
             }
         }

--- a/ReBuzz/Core/PatternCore.cs
+++ b/ReBuzz/Core/PatternCore.cs
@@ -58,12 +58,61 @@ namespace ReBuzz.Core
         public ReadOnlyCollection<IPatternColumn> Columns { get => columns.AsReadOnly(); }
 
         int playPosition;
+
+        public event Action<IPattern> OnPatternPlayStart;
+        public event Action<IPattern> OnPatternPlayPositionChange;
+        public event Action<IPattern> OnPatternPlayEnd;
+
         public int PlayPosition
         {
             get => playPosition;
             set
             {
+                bool playStart = (playPosition == int.MinValue);
+                bool posChange = (playPosition != value);
+                bool playEnd = (value == int.MinValue);
+
                 playPosition = value;
+
+                if (posChange)
+                {
+                    if(playStart)
+                    {
+                        if(OnPatternPlayStart != null)
+                        {
+                            try
+                            {
+                                OnPatternPlayStart(this);
+                            }
+                            catch
+                            { }
+                        }
+                    }
+                    else if(playEnd)
+                    {
+                        if (OnPatternPlayEnd != null)
+                        {
+                            try
+                            {
+                                OnPatternPlayEnd(this);
+                            }
+                            catch
+                            { }
+                        }
+                    }
+                    else if(OnPatternPlayPositionChange != null)
+                    {
+                        if (OnPatternPlayPositionChange != null)
+                        {
+                            try
+                            {
+                                OnPatternPlayPositionChange(this);
+                            }
+                            catch
+                            { }
+                        }
+                    }
+                }
             }
         }
 
@@ -127,6 +176,27 @@ namespace ReBuzz.Core
             CPattern = new IntPtr(patternHandleCounter++);
             columns = new List<IPatternColumn>();
 
+            //Get list of sequences that use this pattern
+            lock (_owningSequences)
+            {
+                foreach (var seq in Global.Buzz.Song.Sequences)
+                {
+                    var mach = seq.Machine;
+                    if (mach != null)
+                    {
+                        foreach (var pat in mach.Patterns.Where(p => p == this))
+                        {
+                            _owningSequences.Add(seq);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            Global.Buzz.Song.SequenceAdded += Song_SequenceAdded;
+            Global.Buzz.Song.SequenceRemoved += Song_SequenceRemoved;
+            Global.Buzz.Song.SequenceChanged += Song_SequenceAdded;
+
             /*
             foreach (var parTrackTuple in Machine.AllParametersAndTracks())
             {
@@ -136,6 +206,51 @@ namespace ReBuzz.Core
             */
             this.dispatcher = dispatcher;
         }
+
+        HashSet<ISequence> _owningSequences = new HashSet<ISequence>();
+
+
+
+        ~PatternCore()
+        {
+            Global.Buzz.Song.SequenceAdded -= Song_SequenceAdded;
+            Global.Buzz.Song.SequenceRemoved -= Song_SequenceRemoved;
+            Global.Buzz.Song.SequenceChanged -= Song_SequenceAdded;
+        }
+
+        private void Song_SequenceAdded(int obj, ISequence seq)
+        {
+            lock (_owningSequences)
+            {
+                //If the added sequence refers to the same machine as the
+                //one associated with the pattern, then associate the sequence with this pattern.
+                if(seq.Machine == Machine)
+                    _owningSequences.Add((ISequence)seq);
+            }
+        }
+
+        private void Song_SequenceRemoved(int obj, ISequence seq)
+        {
+            lock (_owningSequences)
+            {
+                _owningSequences.Remove((ISequence)seq);
+            }
+        }
+        public IReadOnlyCollection<ISequence> Sequences
+        {
+            get
+            {
+                IReadOnlyCollection<ISequence> ret;
+
+                lock (_owningSequences)
+                {
+                    ret = _owningSequences.ToReadOnlyCollection();
+                }
+
+                return ret;
+            }
+        }
+
 
         public event Action<IPatternColumn> ColumnAdded;
         public event Action<IPatternColumn> ColumnRemoved;

--- a/ReBuzz/Core/SongCore.cs
+++ b/ReBuzz/Core/SongCore.cs
@@ -161,9 +161,9 @@ namespace ReBuzz.Core
         string name;
         public string SongName { get => name; internal set { name = value; PropertyChanged.Raise(this, "Name"); } }
 
-        public event Action<int> SequenceAdded;
-        public event Action<int> SequenceRemoved;
-        public event Action<int> SequenceChanged;
+        public event Action<int, ISequence> SequenceAdded;
+        public event Action<int, ISequence> SequenceRemoved;
+        public event Action<int, ISequence> SequenceChanged;
 
         public SongCore(IUiDispatcher dispatcher)
         {
@@ -177,7 +177,7 @@ namespace ReBuzz.Core
                 SequenceCore sequenceCore = new SequenceCore(m as MachineCore);
                 sequences.Insert(index, sequenceCore);
                 PropertyChanged.Raise(this, "Sequences");
-                SequenceAdded?.Invoke(index);
+                SequenceAdded?.Invoke(index, sequenceCore);
             }
 
             Buzz.SetModifiedFlag();
@@ -191,7 +191,7 @@ namespace ReBuzz.Core
                 int index = sequences.IndexOf(sc);
                 sequences.Remove(sc);
                 PropertyChanged.Raise(this, "Sequences");
-                SequenceRemoved?.Invoke(index);
+                SequenceRemoved?.Invoke(index, sc);
                 sc.Release();
             }
             Buzz.SetModifiedFlag();
@@ -205,10 +205,10 @@ namespace ReBuzz.Core
                 int indext = sequences.IndexOf((SequenceCore)t);
                 sequences.RemoveAt(indexs);
                 sequences.Insert(indexs, (SequenceCore)t);
-                SequenceChanged?.Invoke(indexs);
+                SequenceChanged?.Invoke(indexs, t);
                 sequences.RemoveAt(indext);
                 sequences.Insert(indext, (SequenceCore)s);
-                SequenceChanged?.Invoke(indext);
+                SequenceChanged?.Invoke(indext, s);
             }
 
             Buzz.SetModifiedFlag();

--- a/ReBuzzGUI/BuzzGUI.Interfaces/IPattern.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/IPattern.cs
@@ -30,6 +30,14 @@ namespace BuzzGUI.Interfaces
         event Action<IPatternColumn> ColumnRemoved;
         event Action<IPatternColumn> PatternChanged;
         void NotifyPatternChanged();
+
+        IntPtr CPattern { get;  }
+
+        IReadOnlyCollection<ISequence> Sequences { get; }
+
+       event Action<IPattern> OnPatternPlayStart;
+       event Action<IPattern> OnPatternPlayPositionChange;
+       event Action<IPattern> OnPatternPlayEnd;
     }
 
     public interface IPatternEditorColumn

--- a/ReBuzzGUI/BuzzGUI.Interfaces/ISequence.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/ISequence.cs
@@ -44,5 +44,6 @@ namespace BuzzGUI.Interfaces
         // used for live pattern triggering
         void TriggerEvent(int time, SequenceEvent e, bool loop);
 
+        IntPtr CSequence { get; }
     }
 }

--- a/ReBuzzGUI/BuzzGUI.Interfaces/ISong.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/ISong.cs
@@ -19,9 +19,9 @@ namespace BuzzGUI.Interfaces
 
         IDictionary<string, object> Associations { get; }
 
-        event Action<int> SequenceAdded;
-        event Action<int> SequenceRemoved;
-        event Action<int> SequenceChanged;
+        event Action<int, ISequence> SequenceAdded;
+        event Action<int, ISequence> SequenceRemoved;
+        event Action<int, ISequence> SequenceChanged;
 
         void AddSequence(IMachine m, int index);
         void RemoveSequence(ISequence s);

--- a/ReBuzzGUI/BuzzGUI.SequenceEditorExtended Rebuzz/SequenceEditor.xaml.cs
+++ b/ReBuzzGUI/BuzzGUI.SequenceEditorExtended Rebuzz/SequenceEditor.xaml.cs
@@ -192,13 +192,13 @@ namespace BuzzGUI.SequenceEditor
 
 		}
 
-		void song_SequenceAdded(int i)
+		void song_SequenceAdded(int i, ISequence seq)
 		{
 			AddSequence(i);
 			TrackCountChanged();
 		}
 
-		void song_SequenceRemoved(int i)
+		void song_SequenceRemoved(int i, ISequence seq)
 		{
 			trackStack.Children.RemoveAt(i);
 			(trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = null;
@@ -206,10 +206,10 @@ namespace BuzzGUI.SequenceEditor
 			TrackCountChanged();
 		}
 
-		void song_SequenceChanged(int i)
+		void song_SequenceChanged(int i, ISequence seq)
 		{
-			(trackStack.Children[i] as TrackControl).Sequence = song.Sequences[i];
-			(trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = song.Sequences[i];
+            (trackStack.Children[i] as TrackControl).Sequence = seq;
+			(trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = seq;
 		}
 
 		void TrackCountChanged()

--- a/ReBuzzGUI/ModernSequenceEditor/SequenceEditor.xaml.cs
+++ b/ReBuzzGUI/ModernSequenceEditor/SequenceEditor.xaml.cs
@@ -231,13 +231,13 @@ namespace WDE.ModernSequenceEditor
             trackHeaderStack.Children.Insert(i, new TrackHeaderControl(this) { ViewSettings = viewSettings, Width = viewSettings.TrackWidth, HorizontalAlignment = HorizontalAlignment.Left, Resources = this.Resources, Sequence = song.Sequences[i] });
         }
 
-        void song_SequenceAdded(int i)
+        void song_SequenceAdded(int i, ISequence seq)
         {
             AddSequence(i);
             TrackCountChanged();
         }
 
-        void song_SequenceRemoved(int i)
+        void song_SequenceRemoved(int i, ISequence seq)
         {
             var trackControl = trackStack.Children[i] as TrackControl;
             trackControl.Sequence = null;
@@ -248,10 +248,10 @@ namespace WDE.ModernSequenceEditor
             TrackCountChanged();
         }
 
-        void song_SequenceChanged(int i)
+        void song_SequenceChanged(int i, ISequence seq)
         {
-            (trackStack.Children[i] as TrackControl).Sequence = song.Sequences[i];
-            (trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = song.Sequences[i];
+            (trackStack.Children[i] as TrackControl).Sequence = seq;
+            (trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = seq;
         }
 
         void TrackCountChanged()

--- a/ReBuzzGUI/ModernSequenceEditorHorizontal/SequenceEditor.xaml.cs
+++ b/ReBuzzGUI/ModernSequenceEditorHorizontal/SequenceEditor.xaml.cs
@@ -232,13 +232,13 @@ namespace WDE.ModernSequenceEditorHorizontal
             trackHeaderStack.Children.Insert(i, new TrackHeaderControl(this) { ViewSettings = viewSettings, Height = viewSettings.TrackHeight, HorizontalAlignment = HorizontalAlignment.Left, Resources = this.Resources, Sequence = song.Sequences[i] });
         }
 
-        void song_SequenceAdded(int i)
+        void song_SequenceAdded(int i, ISequence seq)
         {
             AddSequence(i);
             TrackCountChanged();
         }
 
-        void song_SequenceRemoved(int i)
+        void song_SequenceRemoved(int i, ISequence seq)
         {
             var trackControl = trackStack.Children[i] as TrackControl;
             trackControl.Sequence = null;
@@ -249,10 +249,10 @@ namespace WDE.ModernSequenceEditorHorizontal
             TrackCountChanged();
         }
 
-        void song_SequenceChanged(int i)
+        void song_SequenceChanged(int i, ISequence seq)
         {
-            (trackStack.Children[i] as TrackControl).Sequence = song.Sequences[i];
-            (trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = song.Sequences[i];
+            (trackStack.Children[i] as TrackControl).Sequence = seq;
+            (trackHeaderStack.Children[i] as TrackHeaderControl).Sequence = seq;
         }
 
         void TrackCountChanged()

--- a/ReBuzzPatternXP/ReBuzzPatternXP.cpp
+++ b/ReBuzzPatternXP/ReBuzzPatternXP.cpp
@@ -357,14 +357,7 @@ void ReBuzzPatternXpMachine::Work()
 {
     //Make sure we're initialised or busy before working...
     if(m_initialised && !m_busy &&  (m_patternEditor != nullptr) && (m_interface != NULL))
-    {  
-        //If we're currently playing, Make sure the machine is told to play a pattern
-        if (Global::Buzz->Playing && (m_host->MasterInfo->PosInTick == 0))
-        {   
-            //Tell native wrapper to tell the pattern editor about the playing pattern
-            m_machineWrapper->NotifyOfPlayingPattern();
-        }
-
+    { 
         //Tick the machine / native buzz machine wrapper
         m_machineWrapper->Tick();
 

--- a/ReBuzzPatternXP/ReBuzzPatternXP.cpp
+++ b/ReBuzzPatternXP/ReBuzzPatternXP.cpp
@@ -130,9 +130,6 @@ ReBuzzPatternXpMachine::ReBuzzPatternXpMachine(IBuzzMachineHost^ host) : m_host(
 
     m_onNewPatternCallback = gcnew MachineWrapper::OnNewPatternDelegate(this, &ReBuzzPatternXpMachine::OnPatternCreated);
     m_machineWrapper->AddNewPatternCallback(m_onNewPatternCallback);
-
-    m_onPatterPlayCallback = gcnew MachineWrapper::OnPatternPlayDelegate(this, &ReBuzzPatternXpMachine::OnPatternPlaying);
-    m_machineWrapper->AddPatternPlayCallback(m_onPatterPlayCallback);
 }
 
 ReBuzzPatternXpMachine::~ReBuzzPatternXpMachine()
@@ -180,12 +177,6 @@ void ReBuzzPatternXpMachine::Release()
     {
         delete m_onNewPatternCallback;
         m_onNewPatternCallback = nullptr;
-    }
-
-    if (m_onPatterPlayCallback != nullptr)
-    {
-        delete m_onPatterPlayCallback;
-        m_onPatterPlayCallback = nullptr;
     }
 
     if (m_sampleListControl != nullptr)
@@ -281,21 +272,6 @@ void ReBuzzPatternXpMachine::OnPatternCreated(IMachine^ rebuzzMachine, void * bu
                 (*foundpat).second->pPattern = reinterpret_cast<CPattern*>(buzzPattern);
         }
     }
-}
-
-bool ReBuzzPatternXpMachine::OnPatternPlaying(IMachine^ rebuzzMachine, void * buzzMachine,
-                                            IPattern^ rebuzzPattern, void * buzzPattern, String^ patternName)
-
-{
-    mi* pmi = reinterpret_cast<mi*>(m_interface);
-
-    //If the playing pattern is not for us, then return false to prevent the exInterface from being called
-    if (pmi->targetMachine != buzzMachine)
-    {
-        return false;
-    }
-
-    return true;
 }
 
 void ReBuzzPatternXpMachine::OnMenuItem_CreatePattern(int menuid)

--- a/ReBuzzPatternXP/ReBuzzPatternXP.h
+++ b/ReBuzzPatternXP/ReBuzzPatternXP.h
@@ -142,10 +142,7 @@ private:
     void OnPatternCreated(IMachine^ rebuzzMachine, void* buzzMachine,
                             IPattern^ rebuzzPattern, void* buzzPattern, String^ patternName);
 
-    bool OnPatternPlaying(IMachine^ rebuzzMachine, void* buzzMachine,
-                          IPattern^ rebuzzPattern, void* buzzPattern, String^ patternName);
-
-
+    
     void OnMenuItem_CreatePattern(int menuid);
     void OnMenuItem_DeletePattern(int menuid);
     void OnMenuItem_PatternProperties(int id);
@@ -165,7 +162,6 @@ private:
     MachineWrapper::KeyboardFocusWindowHandleDelegate^ m_onKbFocusCallback;
     MachineWrapper::OnPatternEditorRedrawDelegate^ m_onEditorRedrawCallback;
     MachineWrapper::OnNewPatternDelegate^ m_onNewPatternCallback;
-    MachineWrapper::OnPatternPlayDelegate^ m_onPatterPlayCallback;
     ContextMenu::OnMenuItemClickDelegate^ m_onCreatePatternMenuCallback;
     ContextMenu::OnMenuItemClickDelegate^ m_onDeletePatternMenuCallback;
     ContextMenu::OnMenuItemClickDelegate^ m_PatternPropertiesMenuCallback;


### PR DESCRIPTION
Fix for PXP sync issue 

I have also added a more effecient mechanism to get sequences and pattersn that PXP is interested in, rather than having to loop over all of the sequences and patterns on each tick
    -  Added pattern play start,  pattern play stopped, and pattern play position change events.  
    -  This allow   NativeMachineFramework  to monitor which patterns have had their play positions changed, and therefore which patterns to iterate over on each tick.

   - Also added sequence collection to each pattern - returning a list of sequences that refer to that pattern.  This allows NativeMachineFramework to iterate only over sequences for each pattern whose play position has changed, from the above.

- Sync issue was caused by using PosInTick, rather than CurrentSubTick.  Changed to use CurrentSubTick  and sync issue is (hopefully) gone. 

- NativeMachineFramework  now uses internal ids of sequences, patterns and machines (which I have exposed via a get property on the interfaces), rather than using the hacky ObjectToInt64.    

Various NativeMachineFramework fixes