### PR TITLE
Update WaveformElement.cs

### DIFF
--- a/ReBuzzGUI/BuzzGUI.WaveformControl/WaveformElement.cs
+++ b/ReBuzzGUI/BuzzGUI.WaveformControl/WaveformElement.cs
@@ -980,8 +980,8 @@ namespace BuzzGUI.WaveformControl
             {
                 if (Waveform != null)
                 {
-                    double frac = (PlayCursor.Offset / ExtentWidth);
-                    return string.Format("CURSOR: {0} (samples) | {0:X4} (hex%)", PlayCursor.OffsetSamples, (int)(frac * 0xFFFE));
+                    double frac = ((double)PlayCursor.OffsetSamples / Waveform.SampleCount);
+                    return string.Format("CURSOR: {0}/{1} (samples) | {2:X4} (hex%)", PlayCursor.OffsetSamples, Waveform.SampleCount, (int)(frac * 0xFFFE));
                 }
                 else
                 {


### PR DESCRIPTION
adds preliminary hex percentage useful for matilde and utrk, matilde users can ignore that last two values of the hex