### PR TITLE
Midi device handling improvements

### DIFF
--- a/ReBuzz/AppViews/MainWindow.xaml.cs
+++ b/ReBuzz/AppViews/MainWindow.xaml.cs
@@ -659,18 +659,18 @@ namespace ReBuzz
                             Buzz.MidiInOutEngine.ReleaseAll();
                             Buzz.MidiInOutEngine.Midi2.CreateMidi2Endpoint();
 
-                            Dictionary<string, bool> midiIns = new Dictionary<string, bool>();
+                            Dictionary<string, Int32> midiIns = new Dictionary<string, Int32>();
                             foreach (var item in preferencesWindow.MidiInControllerCheckboxes)
                             {
-                                midiIns[item.Label] = item.Checked;
+                                midiIns[item.Label] = item.Checked ? 1 : 0;
                             }
                             Buzz.MidiInOutEngine.SetMidiInputDevices2(midiIns);
                             Buzz.MidiInOutEngine.OpenMidiInDevices2();
 
-                            Dictionary<string, bool> midiOuts = new Dictionary<string, bool>();
+                            Dictionary<string, Int32> midiOuts = new Dictionary<string, Int32>();
                             foreach (var item in preferencesWindow.MidiOutControllerCheckboxes)
                             {
-                                midiOuts[item.Label] = item.Checked;
+                                midiOuts[item.Label] = item.Checked ? 1 : 0;
                             }
                             Buzz.MidiInOutEngine.SetMidiOutputDevices2(midiOuts);
                             Buzz.MidiInOutEngine.OpenMidiOutDevices2();

--- a/ReBuzz/AppViews/MainWindow.xaml.cs
+++ b/ReBuzz/AppViews/MainWindow.xaml.cs
@@ -659,20 +659,18 @@ namespace ReBuzz
                             Buzz.MidiInOutEngine.ReleaseAll();
                             Buzz.MidiInOutEngine.Midi2.CreateMidi2Endpoint();
 
-                            List<int> midiIns = new List<int>();
+                            Dictionary<string, bool> midiIns = new Dictionary<string, bool>();
                             foreach (var item in preferencesWindow.MidiInControllerCheckboxes)
-                            {   
-                                if (item.Checked)
-                                    midiIns.Add(item.Id);
+                            {
+                                midiIns[item.Label] = item.Checked;
                             }
                             Buzz.MidiInOutEngine.SetMidiInputDevices2(midiIns);
                             Buzz.MidiInOutEngine.OpenMidiInDevices2();
 
-                            List<int> midiOuts = new List<int>();
+                            Dictionary<string, bool> midiOuts = new Dictionary<string, bool>();
                             foreach (var item in preferencesWindow.MidiOutControllerCheckboxes)
-                            {   
-                                if (item.Checked)
-                                    midiOuts.Add(item.Id);
+                            {
+                                midiOuts[item.Label] = item.Checked;
                             }
                             Buzz.MidiInOutEngine.SetMidiOutputDevices2(midiOuts);
                             Buzz.MidiInOutEngine.OpenMidiOutDevices2();

--- a/ReBuzz/Common/PreferencesWindow.xaml
+++ b/ReBuzz/Common/PreferencesWindow.xaml
@@ -57,7 +57,7 @@
                             </ListBox.ItemContainerStyle>
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <CheckBox IsChecked="{Binding Checked, Mode=TwoWay}" Content="{Binding Label}"/>
+                                    <CheckBox IsEnabled="{Binding Enabled, Mode=TwoWay}" IsChecked="{Binding Checked, Mode=TwoWay}" Content="{Binding Label}"/>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
@@ -124,7 +124,7 @@
                         </ListBox.ItemContainerStyle>
                         <ListBox.ItemTemplate>
                             <DataTemplate>
-                                <CheckBox IsChecked="{Binding Checked, Mode=TwoWay}" Content="{Binding Label}"/>
+                                <CheckBox IsEnabled="{Binding Enabled, Mode=TwoWay}" IsChecked="{Binding Checked, Mode=TwoWay}" Content="{Binding Label}"/>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>

--- a/ReBuzz/Common/PreferencesWindow.xaml.cs
+++ b/ReBuzz/Common/PreferencesWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace ReBuzz.Common
             public int Id { get; set; }
             public string Label { get; set; }
             public bool Checked { get; set; }
+            public bool Enabled { get; set; }
         }
 
         public IList<ControllerCheckboxVM> MidiInControllerCheckboxes { get; set; } = new List<ControllerCheckboxVM>();
@@ -44,17 +45,30 @@ namespace ReBuzz.Common
             DataContext = this;
             InitializeComponent();
 
-            var midiInDevices = buzz.MidiInOutEngine.GetMidiInputDevices();
-            for (int device = 0; device < MidiIn.NumberOfDevices; device++)
+            var midiInDevices = registryEx.ReadDictionary("MIDI Inputs");
+
+            for (int device = 0; device < MidiIn.NumberOfDevices; device++) // List connected devices first
             {
-                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Id = device, Label = MidiIn.DeviceInfo(device).ProductName, Checked = midiInDevices.Contains(device) });
+                var deviceName = MidiIn.DeviceInfo(device).ProductName;
+                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = true, Id = device, Label = deviceName, Checked = midiInDevices.ContainsKey(deviceName) && (Int32)midiInDevices[deviceName] == 1 });
+                midiInDevices.Remove(deviceName);
+            }
+            foreach (var item in midiInDevices)  // Anything remaining in the collection is a disconnected device
+            {
+                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = (Int32)item.Value == 1 });
             }
             lbMidiInputs.InvalidateVisual();
 
-            var midiOutDevices = buzz.MidiInOutEngine.GetMidiOutputDevices();
-            for (int device = 0; device < MidiOut.NumberOfDevices; device++)
+            var midiOutDevices = registryEx.ReadDictionary("MIDI Outputs");
+            for (int device = 0; device < MidiOut.NumberOfDevices; device++) // Connected
             {
-                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Id = device, Label = MidiOut.DeviceInfo(device).ProductName, Checked = midiOutDevices.Contains(device) });
+                var deviceName = MidiOut.DeviceInfo(device).ProductName;
+                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = true, Id = device, Label = deviceName, Checked = midiOutDevices.ContainsKey(deviceName) && (Int32)midiOutDevices[deviceName] == 1 });
+                midiOutDevices.Remove(deviceName);
+            }
+            foreach (var item in midiOutDevices) // Disconnected
+            {
+                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = (Int32)item.Value == 1 });
             }
             lbMidiOutputs.InvalidateVisual();
 

--- a/ReBuzz/Common/PreferencesWindow.xaml.cs
+++ b/ReBuzz/Common/PreferencesWindow.xaml.cs
@@ -45,28 +45,28 @@ namespace ReBuzz.Common
             DataContext = this;
             InitializeComponent();
 
-            var midiInDevices = registryEx.ReadDictionary("MIDI In List");
+            var inputsInfo = registryEx.ReadDictionary("MIDI In List");
 
             for (int device = 0; device < MidiIn.NumberOfDevices; device++) // List connected devices first
             {
                 var deviceName = MidiIn.DeviceInfo(device).ProductName;
-                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = true, Id = device, Label = deviceName, Checked = midiInDevices.ContainsKey(deviceName) && (Int32)midiInDevices[deviceName] == 1 });
-                midiInDevices.Remove(deviceName);
+                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = true, Id = device, Label = deviceName, Checked = inputsInfo.ContainsKey(deviceName) && (Int32)inputsInfo[deviceName] == 1 });
+                inputsInfo.Remove(deviceName);
             }
-            foreach (var item in midiInDevices)  // Anything remaining in the collection is a disconnected device
+            foreach (var item in inputsInfo)  // Anything remaining in the collection is a disconnected device
             {
                 MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = (Int32)item.Value == 1 });
             }
             lbMidiInputs.InvalidateVisual();
 
-            var midiOutDevices = registryEx.ReadDictionary("MIDI Out List");
+            var outputsInfo = registryEx.ReadDictionary("MIDI Out List");
             for (int device = 0; device < MidiOut.NumberOfDevices; device++) // Connected
             {
                 var deviceName = MidiOut.DeviceInfo(device).ProductName;
-                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = true, Id = device, Label = deviceName, Checked = midiOutDevices.ContainsKey(deviceName) && (Int32)midiOutDevices[deviceName] == 1 });
-                midiOutDevices.Remove(deviceName);
+                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = true, Id = device, Label = deviceName, Checked = outputsInfo.ContainsKey(deviceName) && (Int32)outputsInfo[deviceName] == 1 });
+                outputsInfo.Remove(deviceName);
             }
-            foreach (var item in midiOutDevices) // Disconnected
+            foreach (var item in outputsInfo) // Disconnected
             {
                 MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = (Int32)item.Value == 1 });
             }

--- a/ReBuzz/Common/PreferencesWindow.xaml.cs
+++ b/ReBuzz/Common/PreferencesWindow.xaml.cs
@@ -55,7 +55,7 @@ namespace ReBuzz.Common
             }
             foreach (var item in inputsInfo)  // Anything remaining in the collection is a disconnected device
             {
-                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = (Int32)item.Value == 1 });
+                MidiInControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = ((Int32)item.Value & 1) > 0 });
             }
             lbMidiInputs.InvalidateVisual();
 
@@ -68,7 +68,7 @@ namespace ReBuzz.Common
             }
             foreach (var item in outputsInfo) // Disconnected
             {
-                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = (Int32)item.Value == 1 });
+                MidiOutControllerCheckboxes.Add(new ControllerCheckboxVM { Enabled = false, Id = -1, Label = item.Key, Checked = ((Int32)item.Value & 1) > 0 });
             }
             lbMidiOutputs.InvalidateVisual();
 

--- a/ReBuzz/Common/PreferencesWindow.xaml.cs
+++ b/ReBuzz/Common/PreferencesWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace ReBuzz.Common
             DataContext = this;
             InitializeComponent();
 
-            var midiInDevices = registryEx.ReadDictionary("MIDI Inputs");
+            var midiInDevices = registryEx.ReadDictionary("MIDI In List");
 
             for (int device = 0; device < MidiIn.NumberOfDevices; device++) // List connected devices first
             {
@@ -59,7 +59,7 @@ namespace ReBuzz.Common
             }
             lbMidiInputs.InvalidateVisual();
 
-            var midiOutDevices = registryEx.ReadDictionary("MIDI Outputs");
+            var midiOutDevices = registryEx.ReadDictionary("MIDI Out List");
             for (int device = 0; device < MidiOut.NumberOfDevices; device++) // Connected
             {
                 var deviceName = MidiOut.DeviceInfo(device).ProductName;

--- a/ReBuzz/Core/WindowsRegistry.cs
+++ b/ReBuzz/Core/WindowsRegistry.cs
@@ -10,6 +10,7 @@ namespace ReBuzz.Core
         void Write<T>(string key, T x, string path = "BuzzGUI");
         T Read<T>(string key, T def, string path = "BuzzGUI");
         IEnumerable<T> ReadNumberedList<T>(string key, string path = "BuzzGUI");
+        Dictionary<string, object> ReadDictionary(string path = "BuzzGUI");
         void DeleteCurrentUserSubKey(string key);
         IRegistryKey CreateCurrentUserSubKey(string subKey);
     }
@@ -31,6 +32,13 @@ namespace ReBuzz.Core
             IEnumerable<T> numberedList = RegistryEx.ReadNumberedList<T>(key, path);
             Console.WriteLine("ReadNumberedList: " + key + " [" + string.Join(", ", numberedList) + "] " + path);
             return numberedList;
+        }
+
+        public Dictionary<string, object> ReadDictionary(string path = "BuzzGUI")
+        {
+            Dictionary<string, object> values = RegistryEx.ReadDictionary(path);
+            Console.WriteLine("ReadDictionary: " + " [" + string.Join(", ", values) + "] " + path);
+            return values;
         }
 
         public void DeleteCurrentUserSubKey(string key)

--- a/ReBuzz/Midi/MidiEngine.cs
+++ b/ReBuzz/Midi/MidiEngine.cs
@@ -217,6 +217,13 @@ namespace ReBuzz.Midi
 
         public void ReleaseAll()
         {
+            _watcher.Added -= OnDeviceAdded;
+            _watcher.Removed -= OnDeviceRemoved;
+            _watcher.Updated -= OnDeviceUpdated;
+            _watcher.EnumerationCompleted -= OnEnumerationCompleted;
+            _watcher.Stopped -= OnWatcherStopped;
+            _watcher.Stop();
+
             DisposeMidiIn();
             DisposeMidiOuts();
 

--- a/ReBuzz/Midi/MidiEngine.cs
+++ b/ReBuzz/Midi/MidiEngine.cs
@@ -154,37 +154,37 @@ namespace ReBuzz.Midi
 
         internal void OpenMidiInDevices2()
         {
-            var midiIns = registryEx.ReadNumberedList<string>("MidiIn", "MIDI In List").ToList();
+            var midiIns = registryEx.ReadDictionary("MIDI Inputs");
+            
             int midiInDevsCount = MidiIn.NumberOfDevices;
 
-            foreach (var productName in midiIns)
+            foreach (var item in midiIns)
             {
-                for (int i = 0; i < midiInDevsCount; i++)
+                if ((Int32)item.Value == 1)
                 {
-                    if (MidiIn.DeviceInfo(i).ProductName == productName)
+                    for (int i = 0; i < midiInDevsCount; i++)
                     {
-                        CreateMidiIn(i);
-                        break;
+                        if (MidiIn.DeviceInfo(i).ProductName == item.Key)
+                        {
+                            CreateMidiIn(i);
+                            break;
+                        }
                     }
                 }
             }
         }
 
-        internal void SetMidiInputDevices2(List<int> midiInDevices)
+        internal void SetMidiInputDevices2(Dictionary<string, bool> midiInDevices)
         {
+            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Inputs");
             try
             {
-                registryEx.DeleteCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI In List");
+                foreach (var item in midiInDevices)
+                {
+                    regKey.SetValue(item.Key, item.Value ? 1 : 0);
+                }
             }
             catch { }
-
-            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI In List");
-
-            int i = 1;
-            foreach(var id in midiInDevices)
-            {
-                regKey.SetValue("MidiIn" + (i++), MidiIn.DeviceInfo(id).ProductName);
-            }
         }
 
         internal IEnumerable<int> GetMidiOutputDevices()
@@ -193,36 +193,36 @@ namespace ReBuzz.Midi
         }
 
 
-        internal void SetMidiOutputDevices2(List<int> midiOutDevices)
+        internal void SetMidiOutputDevices2(Dictionary<string, bool> midiOutDevices)
         {
+            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Outputs");
             try
             {
-                registryEx.DeleteCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Out List");
+                foreach (var item in midiOutDevices)
+                {
+                    regKey.SetValue(item.Key, item.Value ? 1 : 0);
+                }
             }
             catch { }
-
-            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Out List");
-
-            int i = 1;
-            foreach (var id in midiOutDevices)
-            {
-                regKey.SetValue("MidiOut" + (i++), MidiOut.DeviceInfo(id).ProductName);
-            }
         }
 
         internal void OpenMidiOutDevices2()
         {
-            var midiOuts = registryEx.ReadNumberedList<string>("MidiOut", "MIDI Out List").ToList();
+            var midiOuts = registryEx.ReadDictionary("MIDI Outputs");
+
             int midiOutDevsCount = MidiOut.NumberOfDevices;
 
-            foreach (var productName in midiOuts)
+            foreach (var item in midiOuts)
             {
-                for (int i = 0; i < midiOutDevsCount; i++)
+                if ((Int32)item.Value == 1)
                 {
-                    if (MidiOut.DeviceInfo(i).ProductName == productName)
+                    for (int i = 0; i < midiOutDevsCount; i++)
                     {
-                        CreateMidiOut(i);
-                        break;
+                        if (MidiOut.DeviceInfo(i).ProductName == item.Key)
+                        {
+                            CreateMidiOut(i);
+                            break;
+                        }
                     }
                 }
             }

--- a/ReBuzz/Midi/MidiEngine.cs
+++ b/ReBuzz/Midi/MidiEngine.cs
@@ -154,7 +154,7 @@ namespace ReBuzz.Midi
 
         internal void OpenMidiInDevices2()
         {
-            var midiIns = registryEx.ReadDictionary("MIDI Inputs");
+            var midiIns = registryEx.ReadDictionary("MIDI In List");
             
             int midiInDevsCount = MidiIn.NumberOfDevices;
 
@@ -176,7 +176,7 @@ namespace ReBuzz.Midi
 
         internal void SetMidiInputDevices2(Dictionary<string, bool> midiInDevices)
         {
-            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Inputs");
+            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI In List");
             try
             {
                 foreach (var item in midiInDevices)
@@ -195,7 +195,7 @@ namespace ReBuzz.Midi
 
         internal void SetMidiOutputDevices2(Dictionary<string, bool> midiOutDevices)
         {
-            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Outputs");
+            var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Out List");
             try
             {
                 foreach (var item in midiOutDevices)
@@ -208,7 +208,7 @@ namespace ReBuzz.Midi
 
         internal void OpenMidiOutDevices2()
         {
-            var midiOuts = registryEx.ReadDictionary("MIDI Outputs");
+            var midiOuts = registryEx.ReadDictionary("MIDI Out List");
 
             int midiOutDevsCount = MidiOut.NumberOfDevices;
 

--- a/ReBuzz/Midi/MidiEngine.cs
+++ b/ReBuzz/Midi/MidiEngine.cs
@@ -1,11 +1,13 @@
 ﻿using BuzzGUI.Common;
 using BuzzGUI.Interfaces;
+using NAudio.CoreAudioApi;
 using NAudio.Midi;
 using ReBuzz.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Windows.Devices.Enumeration;
 
 namespace ReBuzz.Midi
 {
@@ -15,6 +17,7 @@ namespace ReBuzz.Midi
         private readonly ReBuzzCore buzz;
         private readonly Dictionary<int, MidiInDevice> midiIns = new Dictionary<int, MidiInDevice>();
         private readonly Dictionary<int, MidiOut> midiOuts = new Dictionary<int, MidiOut>();
+        private DeviceWatcher _watcher;
 
         Midi2 midi2;
 
@@ -26,6 +29,91 @@ namespace ReBuzz.Midi
             this.buzz = buzz;
 
             midi2 = new Midi2(buzz);
+
+            string selector = "System.Devices.InterfaceClassGuid:=\"{6DC23320-AB33-4CE4-80D4-BBB3EBBF2814}\"";
+
+            _watcher = DeviceInformation.CreateWatcher(selector);
+            _watcher.Added += OnDeviceAdded;
+            _watcher.Removed += OnDeviceRemoved;
+            _watcher.Updated += OnDeviceUpdated;
+            _watcher.EnumerationCompleted += OnEnumerationCompleted;
+            _watcher.Stopped += OnWatcherStopped;
+
+            _watcher.Start();
+        }
+        private void OnDeviceAdded(DeviceWatcher sender, DeviceInformation args)
+        {
+            // New device spotted. Called a lot when watcher is started as it enumerates the installed (not connected) MIDI devices
+            //buzz.DCWriteLine("OnDeviceAdded");
+        }
+
+        private void OnDeviceRemoved(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+            // A known device was removed (uninstalled)
+            //buzz.DCWriteLine("OnDeviceRemoved");
+        }
+
+        private async void OnDeviceUpdated(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+            // A device that we already know about has changed somehow (connected, disconnected, other?)
+
+            int midiInDevsCount = MidiIn.NumberOfDevices;
+            int midiOutDevsCount = MidiOut.NumberOfDevices;
+
+            var info = await DeviceInformation.CreateFromIdAsync(args.Id);
+
+            if (info.IsEnabled)
+            {
+                buzz.DCWriteLine("Device connected: " + info.Name);
+
+                var inputsInfo = registryEx.ReadDictionary("MIDI In List");
+                if(inputsInfo.ContainsKey(info.Name))
+                {
+                    if((Int32)inputsInfo[info.Name] == 1)
+                    {   
+                        for (int i = 0; i < midiInDevsCount; i++)
+                        {
+                            if (MidiIn.DeviceInfo(i).ProductName == info.Name)
+                            {
+                                CreateMidiIn(i);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                var outputsInfo= registryEx.ReadDictionary("MIDI Out List");
+                if (outputsInfo.ContainsKey(info.Name))
+                {
+                    if ((Int32)outputsInfo[info.Name] == 1)
+                    {
+                        for (int i = 0; i < midiOutDevsCount; i++)
+                        {
+                            if (MidiOut.DeviceInfo(i).ProductName == info.Name)
+                            {
+                                CreateMidiOut(i);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                buzz.DCWriteLine("Device disconnected: " + info.Name);
+            }
+        }
+
+        private void OnEnumerationCompleted(DeviceWatcher sender, object args)
+        {
+            // Watcher has finished enumerating devices
+            //buzz.DCWriteLine("OnEnumerationCompleted");
+        }
+
+        private void OnWatcherStopped(DeviceWatcher sender, object args)
+        {
+            // The watcher has stopped watching
+            //buzz.DCWriteLine("OnWatcherStopped");
         }
 
         public void CreateMidiIn(int selectedDeviceIndex)
@@ -154,11 +242,11 @@ namespace ReBuzz.Midi
 
         internal void OpenMidiInDevices2()
         {
-            var midiIns = registryEx.ReadDictionary("MIDI In List");
+            var inputsInfo = registryEx.ReadDictionary("MIDI In List");
             
             int midiInDevsCount = MidiIn.NumberOfDevices;
 
-            foreach (var item in midiIns)
+            foreach (var item in inputsInfo)
             {
                 if ((Int32)item.Value == 1)
                 {
@@ -208,11 +296,11 @@ namespace ReBuzz.Midi
 
         internal void OpenMidiOutDevices2()
         {
-            var midiOuts = registryEx.ReadDictionary("MIDI Out List");
+            var outputsInfo = registryEx.ReadDictionary("MIDI Out List");
 
             int midiOutDevsCount = MidiOut.NumberOfDevices;
 
-            foreach (var item in midiOuts)
+            foreach (var item in outputsInfo)
             {
                 if ((Int32)item.Value == 1)
                 {

--- a/ReBuzz/Midi/MidiEngine.cs
+++ b/ReBuzz/Midi/MidiEngine.cs
@@ -30,6 +30,8 @@ namespace ReBuzz.Midi
 
             midi2 = new Midi2(buzz);
 
+            CheckRegistryDataFormat();
+
             string selector = "System.Devices.InterfaceClassGuid:=\"{6DC23320-AB33-4CE4-80D4-BBB3EBBF2814}\"";
 
             _watcher = DeviceInformation.CreateWatcher(selector);
@@ -235,6 +237,37 @@ namespace ReBuzz.Midi
             return list;
         }
 
+        internal void CheckRegistryDataFormat()
+        {
+            long version = registryEx.Read("MIDIDeviceFormat", 1, "Settings");
+
+            if(version == 1)
+            {
+                // Convert MidiOut1 = SomeDevice to SomeDevice = flags
+                // flags is just 1 for enabled now but may add more (eg. hidden)
+                var inputsInfoOld = registryEx.ReadDictionary("MIDI In List");
+                Dictionary<string, Int32> inputsInfo = new Dictionary<string, Int32>();
+                foreach (var item in inputsInfoOld)
+                {
+                    inputsInfo.Add((string)item.Value, 1);
+                }
+
+                registryEx.DeleteCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI In List");
+                SetMidiInputDevices2(inputsInfo);
+
+                var outputsInfoOld = registryEx.ReadDictionary("MIDI Out List");
+                Dictionary<string, Int32> outputsInfo = new Dictionary<string, Int32>();
+                foreach (var item in outputsInfoOld)
+                {
+                    outputsInfo.Add((string)item.Value, 1);
+                }
+                registryEx.DeleteCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Out List");
+                SetMidiOutputDevices2(outputsInfo);
+            }
+
+            registryEx.Write("MIDIDeviceFormat", 2, "Settings");
+        }
+
         internal IEnumerable<int> GetMidiInputDevices()
         {
             return midiIns.Keys.ToReadOnlyCollection();
@@ -248,7 +281,7 @@ namespace ReBuzz.Midi
 
             foreach (var item in inputsInfo)
             {
-                if ((Int32)item.Value == 1)
+                if (((Int32)item.Value & 1) > 0) // Flags & 1 == enabled
                 {
                     for (int i = 0; i < midiInDevsCount; i++)
                     {
@@ -262,14 +295,14 @@ namespace ReBuzz.Midi
             }
         }
 
-        internal void SetMidiInputDevices2(Dictionary<string, bool> midiInDevices)
+        internal void SetMidiInputDevices2(Dictionary<string, Int32> midiInDevices)
         {
             var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI In List");
             try
             {
                 foreach (var item in midiInDevices)
                 {
-                    regKey.SetValue(item.Key, item.Value ? 1 : 0);
+                    regKey.SetValue(item.Key, item.Value); // DeviceName = BitFlags
                 }
             }
             catch { }
@@ -281,14 +314,14 @@ namespace ReBuzz.Midi
         }
 
 
-        internal void SetMidiOutputDevices2(Dictionary<string, bool> midiOutDevices)
+        internal void SetMidiOutputDevices2(Dictionary<string, Int32> midiOutDevices)
         {
             var regKey = registryEx.CreateCurrentUserSubKey(buzz.registryRoot + "\\" + "MIDI Out List");
             try
             {
                 foreach (var item in midiOutDevices)
                 {
-                    regKey.SetValue(item.Key, item.Value ? 1 : 0);
+                    regKey.SetValue(item.Key, item.Value); // DeviceName = BitFlags
                 }
             }
             catch { }
@@ -302,7 +335,7 @@ namespace ReBuzz.Midi
 
             foreach (var item in outputsInfo)
             {
-                if ((Int32)item.Value == 1)
+                if (((Int32)item.Value & 1) > 0) // Flags & 1 == enabled
                 {
                     for (int i = 0; i < midiOutDevsCount; i++)
                     {

--- a/ReBuzzGUI/BuzzGUI.Common/RegistryEx.cs
+++ b/ReBuzzGUI/BuzzGUI.Common/RegistryEx.cs
@@ -110,6 +110,34 @@ namespace BuzzGUI.Common
             return ret;
         }
 
+        public static Dictionary<string, object> ReadDictionary(string path = "BuzzGUI")
+        {
+            Dictionary<string, object> ret = new Dictionary<string, object>();
+            Microsoft.Win32.RegistryKey? regkey = null;
+            try
+            {
+                regkey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(regpath + "\\" + path);
+                if (regkey == null)
+                    return ret;
+
+                var keys = regkey.GetValueNames();
+                foreach (var k in keys)
+                {
+                    ret.Add(k, regkey.GetValue(k));
+                }
+            }
+            finally
+            {
+                if (regkey != null)
+                {
+                    regkey.Close();
+                    regkey.Dispose();
+                }
+            }
+
+            return ret;
+        }
+
         public static RegistryMonitor CreateMonitor(string path = "BuzzGUI")
         {
             return new RegistryMonitor(Microsoft.Win32.RegistryHive.CurrentUser, regpath + path);

--- a/ReBuzzTests/Automation/FakeInMemoryRegistry.cs
+++ b/ReBuzzTests/Automation/FakeInMemoryRegistry.cs
@@ -124,5 +124,10 @@ namespace ReBuzzTests.Automation
                 return new FakeInMemoryRegistryKey(registryDictionary, path);
             }
         }
+
+        public Dictionary<string, object> ReadDictionary(string path = "BuzzGUI")
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
MIDI devices are now permanently remembered when disconnected and will be automatically re-opened when reconnected, without needing to open the Preferences window.

The way device information is stored in the registry keys has been changed, a new value "MIDIDeviceFormat" was added to the Settings registry, and a method was implemented to automatically convert old data to the new format.

WindowsRegistry.ReadDictionary() was added to facilitate the new data format. This could probably be improved by changing "object" in the returned Dictionary to a templated type, to avoid having to keep casting the values to the required type.