### PR TITLE
Modern Pattern Editor: shift values by +12/-12 and enable velocity in Midi Edit mode

### DIFF
--- a/ModernPatternEditor/ModernPatternEditor.NET/Help.xaml
+++ b/ModernPatternEditor/ModernPatternEditor.NET/Help.xaml
@@ -297,6 +297,14 @@
                             <Paragraph>Shift Values</Paragraph>
                         </TableCell>
                     </TableRow>
+					<TableRow>
+						<TableCell>
+							<Paragraph>Ctrl+Shift+Add/Subtract</Paragraph>
+						</TableCell>
+						<TableCell>
+							<Paragraph>Shift Values by +12/-12</Paragraph>
+						</TableCell>
+					</TableRow>
                     <TableRow>
                         <TableCell>
                             <Paragraph>Ctrl+1,2,3...</Paragraph>

--- a/ModernPatternEditor/ModernPatternEditor.NET/Help.xaml
+++ b/ModernPatternEditor/ModernPatternEditor.NET/Help.xaml
@@ -297,14 +297,14 @@
                             <Paragraph>Shift Values</Paragraph>
                         </TableCell>
                     </TableRow>
-					<TableRow>
-						<TableCell>
-							<Paragraph>Ctrl+Shift+Add/Subtract</Paragraph>
-						</TableCell>
-						<TableCell>
-							<Paragraph>Shift Values by +12/-12</Paragraph>
-						</TableCell>
-					</TableRow>
+                    <TableRow>
+                        <TableCell>
+                            <Paragraph>Ctrl+Shift+Add/Subtract</Paragraph>
+                        </TableCell>
+                        <TableCell>
+                            <Paragraph>Shift Values by +12/-12</Paragraph>
+                        </TableCell>
+                    </TableRow>
                     <TableRow>
                         <TableCell>
                             <Paragraph>Ctrl+1,2,3...</Paragraph>

--- a/ModernPatternEditor/ModernPatternEditor.NET/PatternControl.xaml.cs
+++ b/ModernPatternEditor/ModernPatternEditor.NET/PatternControl.xaml.cs
@@ -608,6 +608,16 @@ namespace WDE.ModernPatternEditor
                         if (n == 0) n = 10;
                         SetBeatSubdivision(10 + n);
                     }
+                    else if (e.Key == Key.Add)
+                    {
+                        ShiftValues(12);
+                        e.Handled = true;
+                    }
+                    else if (e.Key == Key.Subtract)
+                    {
+                        ShiftValues(-12);
+                        e.Handled = true;
+                    }
                     else if (e.Key == Key.Delete)
                     {
                         InsertOrDelete(false, true);

--- a/ModernPatternEditor/ModernPatternEditor.NET/PatternEditor.xaml
+++ b/ModernPatternEditor/ModernPatternEditor.NET/PatternEditor.xaml
@@ -198,6 +198,9 @@
                                     <CheckBox Name="midiEditBox" Visibility="{Binding KeyboardMappingVisibility}" Height="21" Margin="0,0,4,0" FlowDirection="RightToLeft" IsChecked="{Binding MidiEdit, Mode=TwoWay}" IsEnabled="{Binding SelectedMachine.HasSelectedPattern}">
                                         <Label Visibility="{Binding KeyboardMappingVisibility}" VerticalAlignment="Center" Margin="0,-4,0,0">:Midi Edit</Label>
                                     </CheckBox>
+                                    <CheckBox Name="midiVelocityBox" Visibility="{Binding KeyboardMappingVisibility}" Height="21" Margin="0,0,4,0" FlowDirection="RightToLeft" IsChecked="{Binding MidiVelocity, Mode=TwoWay}" IsEnabled="{Binding SelectedMachine.HasSelectedPattern}">
+                                        <Label Visibility="{Binding KeyboardMappingVisibility}" VerticalAlignment="Center" Margin="0,-4,0,0">:Midi Velocity</Label>
+                                    </CheckBox>
 
                                     <!--
                                     <ToggleButton Width="14" Height="14" VerticalAlignment="Center" Margin="4,4,0,4" Focusable="False" Padding="0" FontSize="9" Content="E" ToolTip="Select Pattern Editor" IsChecked="{Binding IsSelectPatternEditorVisible}"/>

--- a/ModernPatternEditor/ModernPatternEditor.NET/PatternEditor.xaml.cs
+++ b/ModernPatternEditor/ModernPatternEditor.NET/PatternEditor.xaml.cs
@@ -46,6 +46,8 @@ namespace WDE.ModernPatternEditor
 
         public bool MidiEdit { get; set; }
 
+        public bool MidiVelocity { get; set; }
+
         int selectedStepsDown = 1;
         public int SelectedStepsDown { get => selectedStepsDown; set { selectedStepsDown = value; PropertyChanged.Raise(this, "SelectedStepsDown"); } }
 
@@ -971,13 +973,41 @@ namespace WDE.ModernPatternEditor
                         int time = cursor.TimeInBeat + cursor.Beat * PatternControl.BUZZ_TICKS_PER_BEAT * PatternEvent.TimeBase;
                         MPEPattern mpePattern = MPEPatternsDB.GetMPEPattern(patternControl.Pattern.Pattern);
                         MPEPatternColumn mpeColumn = mpePattern.GetColumn(cursor.ParameterColumn.PatternColumn);
+                        MPEPatternColumn midiVelocityColumn = MidiVelocity ? GetNoteVelocityColumn(mpePattern, cursor.ParameterColumn.PatternColumn.Track) : null;
+
                         Dispatcher.Invoke(() =>
                         {
                             if (patternControl.IsKeyboardFocused)
                             {
-                                DoAction(new MPESetOrClearEventsAction(patternControl.Pattern.Pattern, mpeColumn, new PatternEvent[] { new PatternEvent() { Time = time, Value = buzzNote } }, true));
+                                using (new ActionGroup(EditContext.ActionStack))
+                                {
+                                    DoAction(
+                                        new MPESetOrClearEventsAction(
+                                            patternControl.Pattern.Pattern,
+                                            mpeColumn,
+                                            new PatternEvent[] { new PatternEvent() { Time = time, Value = buzzNote } },
+                                            true));
+
+                                    if (midiVelocityColumn != null)
+                                    {
+                                        DoAction(
+                                            new MPESetOrClearEventsAction(
+                                                patternControl.Pattern.Pattern,
+                                                midiVelocityColumn,
+                                                new PatternEvent[]
+                                                {
+                                                    new PatternEvent() { Time = time, Value = velocity }
+                                                },
+                                                true));
+                                    }
+                                }
+
                                 patternControl.MoveCursorDelta(SelectedStepsRight, SelectedStepsDown);
-                                playRecordManager.UpdatePlayingNotePattern(mpeColumn.Parameter, mpeColumn.ParamTrack, buzzNote, velocity);
+                                playRecordManager.UpdatePlayingNotePattern(
+                                    mpeColumn.Parameter,
+                                    mpeColumn.ParamTrack,
+                                    buzzNote,
+                                    velocity);
                             }
                         });
                     }
@@ -1212,6 +1242,13 @@ namespace WDE.ModernPatternEditor
         internal void PatternChanged(IPattern pattern)
         {
             changedPatternsSinceLastTick.TryAdd(pattern, true);
+        }
+
+        private static MPEPatternColumn? GetNoteVelocityColumn(MPEPattern mpePattern, int track)
+        {
+            return PatternEditorUtils.GetColumn(mpePattern, "note velocity", track)
+                ?? PatternEditorUtils.GetColumn(mpePattern, "volume", track)
+                ?? PatternEditorUtils.GetColumn(mpePattern, "velocity", track);
         }
 
         #region INotifyPropertyChanged Members

--- a/ModernPatternEditor/ModernPatternEditor.NET/PatternEditorUtils.cs
+++ b/ModernPatternEditor/ModernPatternEditor.NET/PatternEditorUtils.cs
@@ -696,7 +696,7 @@ namespace WDE.ModernPatternEditor
             return false;
         }
 
-        private static MPEPatternColumn? GetColumn(MPEPattern mpePattern, string name, int t)
+        public static MPEPatternColumn? GetColumn(MPEPattern mpePattern, string name, int t)
         {
             foreach (var c in mpePattern.MPEPatternColumns)
             {


### PR DESCRIPTION
For picking the midi velocity column, I looked at some of the frequently used names and picked three: "note velocity", "velocity" and "volume". Could expand that or use a different mechanism if there is a better one.