### PR TITLE
Replace FirstOrDefault master lookup in ReadWork with MachinesList[0]

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -579,9 +579,9 @@ namespace ReBuzz.Audio
                 m.workDone = false;
 
             // Iterate machine connection graph staring from Master
-            var master = buzzCore.SongCore.MachinesList.FirstOrDefault(m => m.DLL.Info.Type == MachineType.Master);
-            if (master == null)
+            if (buzzCore.SongCore.MachinesList.Count == 0)
                 return workSamplesCount;
+            var master = buzzCore.SongCore.MachinesList[0];
 
             if (!multiThreadingEnabled)
             {


### PR DESCRIPTION
Small follow-up to a pattern already in this file.

`UpdateMasterParams` (line 268) uses `MachinesList[0]` for the master lookup; `ReadWork` (around line 582) was still doing the equivalent `FirstOrDefault(m => m.DLL.Info.Type == MachineType.Master)` linear scan with a closure. The Master is always at index 0 of `MachinesList` and never reordered, so the two are equivalent — this just applies the existing pattern to the second hot site.

Verified:
- Solution builds cleanly with the change.
- Smoke-tested: ReBuzz runs, Infector pattern plays as expected.

Happy to revise if there's a different convention preferred here.