### PR TITLE
Skip propagating unchanged structural fields in UpdateMasterAndSubTic…

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -296,6 +296,7 @@ namespace ReBuzz.Audio
                     subTickInfo.SubTickReminderCounter -= subTickInfo.SubTicksPerTick;
                     subTickInfo.SamplesPerSubTick++;
                 }
+                ReBuzzCore.masterInfoStructDirty = true;
             }
         }
 

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -81,6 +81,7 @@ namespace ReBuzz.Core
         public static int buildNumber = int.Parse(Resources.BuildNumber);
         public static MasterInfoExtended masterInfo;
         public static SubTickInfoExtended subTickInfo;
+        internal static volatile bool masterInfoStructDirty = true;
         public static readonly int SubTicsPerTick = 8;
         internal static BuzzGlobalState GlobalState;
         public static string AppDataPath = "ReBuzz";
@@ -584,6 +585,7 @@ namespace ReBuzz.Core
                 subTickInfo.PosInSubTick = 0;
 
                 subTickInfo.SubTickReminderCounter = 0;// masterInfo.SamplesPerTick % subTickInfo.SubTicksPerTick;
+                masterInfoStructDirty = true;
             }
         }
 

--- a/ReBuzz/MachineManagement/MachineManager.cs
+++ b/ReBuzz/MachineManagement/MachineManager.cs
@@ -977,10 +977,36 @@ namespace ReBuzz.MachineManagement
 
         internal void UpdateMasterAndSubTickInfoToHost()
         {
+            bool structDirty = ReBuzzCore.masterInfoStructDirty;
+            if (structDirty)
+                ReBuzzCore.masterInfoStructDirty = false;
+
+            var masterInfo = ReBuzzCore.masterInfo;
+            var subTickInfo = ReBuzzCore.subTickInfo;
+
             foreach (var machineHost in managedMachines.Values)
             {
-                if (machineHost != null)
-                    UpdateMasterAndSubTickInfo(machineHost);
+                if (machineHost == null) continue;
+
+                var hostInfo = machineHost.MasterInfo;
+                var hostSubTick = machineHost.SubTickInfo;
+
+                // Position fields - always copy (advance every chunk)
+                hostInfo.PosInTick = masterInfo.PosInTick;
+                hostSubTick.CurrentSubTick = subTickInfo.CurrentSubTick;
+                hostSubTick.PosInSubTick = subTickInfo.PosInSubTick;
+
+                if (structDirty)
+                {
+                    // Structural fields - only when changed
+                    hostInfo.SamplesPerTick = masterInfo.SamplesPerTick;
+                    hostInfo.BeatsPerMin = masterInfo.BeatsPerMin;
+                    hostInfo.TicksPerBeat = masterInfo.TicksPerBeat;
+                    hostInfo.SamplesPerSec = masterInfo.SamplesPerSec;
+                    hostInfo.TicksPerSec = masterInfo.TicksPerSec;
+                    hostSubTick.SubTicksPerTick = subTickInfo.SubTicksPerTick;
+                    hostSubTick.SamplesPerSubTick = subTickInfo.SamplesPerSubTick;
+                }
             }
         }
 


### PR DESCRIPTION
`UpdateMasterAndSubTickInfoToHost` walked every managed machine host and copied 10 master/sub-tick fields each, on every audio chunk, regardless of whether anything had changed. This change splits the propagation by lifetime of the data:

- **Position fields** (`PosInTick`, `CurrentSubTick`, `PosInSubTick`) — copy every chunk as before, since they advance with each audio buffer.
- **Structural fields** (`SamplesPerTick`, `BeatsPerMin`, `TicksPerBeat`, `SamplesPerSec`, `TicksPerSec`, `SubTicksPerTick`, `SamplesPerSubTick`) — copy only when they actually change.

A new internal flag `ReBuzzCore.masterInfoStructDirty` is set `true` at every mutation site:

- At the end of `ReBuzzCore.UpdateMasterInfo()` — catches BPM/TPB changes (the `BPM`/`TPB` setters route through this method), sample-rate changes (via the `SelectedAudioDriverSampleRate` setter), `SubTickResolution` changes, and any other UI-driven structural mutation.
- Inside the `if (PosInSubTick == 0)` block in `WorkManager.UpdateSubTickLength` — catches the periodic `SamplesPerSubTick` recompute at subtick boundaries.

The flag is read-and-cleared once per call to `UpdateMasterAndSubTickInfoToHost`, into a local `structDirty` bool used for the conditional. A race against a parallel setter that fires between read and clear at worst causes one duplicate propagation on this chunk (with a guaranteed propagation on the next), never a missed one.

`UpdateMasterAndSubTickInfo` (the single-host variant, used at machine-add time) is unchanged — that path needs to guarantee full propagation, so the optimisation doesn't apply there.

Verified:
- Solution builds cleanly with the change.
- Smoke-tested with a PedalChord-driving-Juno106 song with arpeggio. Steady playback unaffected, live BPM changes propagate to managed machines correctly, sample-rate switching in settings also propagates correctly.

Happy to revise if there's a different convention for where the dirty flag should live, or if the split itself should be done differently.