### PR TITLE
Skip MasterTapSamples buffer allocation when no MasterTap subscriber

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1659,7 +1659,6 @@ namespace ReBuzz.Core
         internal Gear Gear { get; }
         internal void MasterTapSamples(float[] resSamples, int offset, int count)
         {
-            var s = GetSongTime();
             float scale = (1.0f / 32768.0f);
             for (int i = 0; i < count; i += 2)
             {
@@ -1670,6 +1669,9 @@ namespace ReBuzz.Core
             maxSampleLeft *= scale;
             maxSampleRight *= scale;
 
+            if (MasterTap == null) return;
+
+            var s = GetSongTime();
             float[] samples = new float[count];
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
`MasterTapSamples` ran a `new float[count]` allocation, a copy loop, and a dispatcher `BeginInvoke` on every audio chunk, regardless of whether `MasterTap` had a subscriber. When no subscriber is listening (the typical playback case), all of that work is wasted.

The peak-level computation that drives the master VU meter must still run on every chunk (it's read elsewhere for the meter display), but the allocation and dispatch path can be skipped entirely when nobody's listening.

This PR:
- Adds an early `return` immediately after the meter math when `MasterTap == null`
- Moves `GetSongTime()` to after the early-out, since it's only consumed by the dispatched callback's closure

The existing null check inside the `BeginInvoke` callback is preserved as defense against an unsubscribe between dispatch and execution.

Verified:
- Built cleanly
- VU meters (top master meter + inter-machine link meters) continue to display normally
- Normal playback unaffected

Note: this is the first of a two-PR pair. A follow-up PR will replace the per-chunk allocation with a ring buffer; that one is a contract change for subscribers (must consume synchronously), so it's separated here. This PR has no semantic change.

Happy to revise.