### PR TITLE
Perf/tap samples ring buffer

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1656,6 +1656,12 @@ namespace ReBuzz.Core
         float maxSampleLeft;
         float maxSampleRight;
 
+        // Ring of buffers for MasterTapSamples — reused across calls to avoid per-chunk allocation.
+        // Subscribers MUST consume the buffer synchronously inside the BeginInvoke callback;
+        // after N=4 further calls the slot will be overwritten by the audio thread.
+        private readonly float[][] tapBuffers = new float[4][];
+        private int tapBufferIndex;
+
         internal Gear Gear { get; }
         internal void MasterTapSamples(float[] resSamples, int offset, int count)
         {
@@ -1672,7 +1678,14 @@ namespace ReBuzz.Core
             if (MasterTap == null) return;
 
             var s = GetSongTime();
-            float[] samples = new float[count];
+            float[] samples = tapBuffers[tapBufferIndex];
+            if (samples == null || samples.Length != count)
+            {
+                samples = new float[count];
+                tapBuffers[tapBufferIndex] = samples;
+            }
+            tapBufferIndex = (tapBufferIndex + 1) & 3;
+
             for (int i = 0; i < count; i++)
             {
                 samples[i] = resSamples[offset + i];

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1659,7 +1659,6 @@ namespace ReBuzz.Core
         internal Gear Gear { get; }
         internal void MasterTapSamples(float[] resSamples, int offset, int count)
         {
-            var s = GetSongTime();
             float scale = (1.0f / 32768.0f);
             for (int i = 0; i < count; i += 2)
             {
@@ -1670,6 +1669,9 @@ namespace ReBuzz.Core
             maxSampleLeft *= scale;
             maxSampleRight *= scale;
 
+            if (MasterTap == null) return;
+
+            var s = GetSongTime();
             float[] samples = new float[count];
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
This PR is stacked on top of #92 — please review #92 first. Until #92 merges, this PR's diff includes both the early-out (from #92) AND the ring-buffer change introduced here. Once #92 merges into main, this diff will automatically reduce to just the ring-buffer change.

Building on the null early-out in #92, this PR eliminates the per-chunk allocation entirely. Instead of `new float[count]` on every audio chunk, a ring of four pre-allocated buffers is reused: the audio thread rotates through slots, and each chunk reuses a slot the dispatcher will have consumed several chunks earlier.

Steady state: zero allocations in `MasterTapSamples`. The slot is reallocated only on first use (each of the four slots, lazy-init) or when `count` changes (e.g. user changes ASIO buffer size mid-session).

**Contract change** for `MasterTap` subscribers: the `float[]` passed to the `BeginInvoke` callback must be consumed synchronously inside that callback. After four further calls the slot will be overwritten by the audio thread. The existing recorder path consumes synchronously and is unaffected. A comment above the ring-buffer fields makes the contract explicit for future readers.

Ring size of 4 is generous given that:
- Audio chunks at 48kHz / ~256 samples are ~5ms apart
- UI dispatcher latency is sub-millisecond in normal operation
- So a slot has ~20ms of "safe" lifetime before the audio thread loops back

A power-of-two size lets the wrap use `& 3` rather than `% 4` for explicit intent (the JIT optimises the modulo anyway, but the intent is clearer this way).

Verified:
- Built cleanly
- Normal playback unaffected
- VU meters continue to display normally (top master + inter-machine link meters)
- Recording to disk produces correct output (modulo Debug-build crackles, unrelated)
- ASIO buffer-size changes mid-playback handled correctly (size-mismatch reallocation path exercised)

Happy to revise — particularly if the ring size should be different, or if there's a subscriber path you're aware of that doesn't consume synchronously.