### PR TITLE
Use CollectionsMarshal.AsSpan + CopyTo for IPC byte buffer copies

### DIFF
--- a/ReBuzz/NativeMachine/NativeMessage.cs
+++ b/ReBuzz/NativeMachine/NativeMessage.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Xml.Linq;
 
@@ -146,10 +147,9 @@ namespace ReBuzz.NativeMachine
 
             if (size > MessageBuffer.MaxSize)
             {
-                for (int i = 0; i < MessageBuffer.MaxSize; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, MessageBuffer.MaxSize);
+                var dst = new Span<byte>(dataRootPointer, MessageBuffer.MaxSize);
+                src.CopyTo(dst);
 
                 sendMessageDataoffset += MessageBuffer.MaxSize;
                 size = MessageBuffer.MaxSize;
@@ -158,11 +158,10 @@ namespace ReBuzz.NativeMachine
             }
             else
             {
-                for (int i = 0; i < size; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
-                
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, size);
+                var dst = new Span<byte>(dataRootPointer, size);
+                src.CopyTo(dst);
+
                 done = true;
                 sendMessageDataoffset = 0;
                 SetChannelState(ChannelState.sendlastbuffer);
@@ -275,10 +274,9 @@ namespace ReBuzz.NativeMachine
 
             if (size > MessageBuffer.MaxSize)
             {
-                for (int i = 0; i < MessageBuffer.MaxSize; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, MessageBuffer.MaxSize);
+                var dst = new Span<byte>(dataRootPointer, MessageBuffer.MaxSize);
+                src.CopyTo(dst);
 
                 sendMessageDataoffset += MessageBuffer.MaxSize;
                 size = MessageBuffer.MaxSize;
@@ -294,10 +292,9 @@ namespace ReBuzz.NativeMachine
             }
             else
             {
-                for (int i = 0; i < size; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, size);
+                var dst = new Span<byte>(dataRootPointer, size);
+                src.CopyTo(dst);
 
                 done = true;
                 sendMessageDataoffset = 0;


### PR DESCRIPTION
`CopyMessageToSendBuffer` and `CopyReplyMessageToSendBuffer` each had two byte-by-byte `for`-loops copying from `sendMessageData` (a `List<byte>`) into the unmanaged `dataRootPointer` buffer, indexing the List per element. The List indexer has per-call overhead — bounds check plus virtual dispatch through `IList` — that adds up across thousands of bytes per message.

This PR replaces all four loops with:

```csharp
var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, size);
var dst = new Span<byte>(dataRootPointer, size);
src.CopyTo(dst);
```

`CollectionsMarshal.AsSpan` exposes the `List<byte>`'s underlying array directly with no indirection, and `Span<byte>.CopyTo` over disjoint regions lowers to vectorised memcpy in the JIT. Same bytes copied in the same order, just in one operation per branch instead of N.

The same pattern appears twice — once in `CopyMessageToSendBuffer` (the regular send path), once in `CopyReplyMessageToSendBuffer` (the reply path with its `IsCallback()` channel-state distinction). Both methods get the same treatment.

Added `using System.Runtime.InteropServices;` (in alphabetical position) for `CollectionsMarshal`.

Verified:
- Built cleanly
- Tested with a song running both an Infector native machine and a Tal Sampler VST simultaneously — both exercise the IPC path heavily, played correctly with no audio artefacts

No semantic change; pure speedup.

Happy to revise.