### PR TITLE
Perf/ipc bulk sample write

### DIFF
--- a/ReBuzz/NativeMachine/NativeMessage.cs
+++ b/ReBuzz/NativeMachine/NativeMessage.cs
@@ -1349,28 +1349,28 @@ namespace ReBuzz.NativeMachine
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void SetMessageData(Sample[] data, int nSamples, bool stereo)
+        public void SetMessageData(Sample[] data, int nSamples, bool stereo)
         {
-            byte[] array = intArray;
-            fixed (byte* ptr = array)
+            if (stereo)
             {
-                if (stereo)
+                // Sample is { float L; float R; } with no padding, so the array's byte
+                // representation is exactly what the IPC channel expects — bulk-copy in one shot.
+                var srcBytes = MemoryMarshal.AsBytes(data.AsSpan(0, nSamples));
+                int startIndex = sendMessageData.Count;
+                CollectionsMarshal.SetCount(sendMessageData, startIndex + srcBytes.Length);
+                srcBytes.CopyTo(CollectionsMarshal.AsSpan(sendMessageData).Slice(startIndex, srcBytes.Length));
+            }
+            else
+            {
+                // Mono: mix L+R per sample, write directly into a pre-sized destination
+                // span reinterpreted as floats rather than per-sample AddRange.
+                int totalBytes = nSamples * 4;
+                int startIndex = sendMessageData.Count;
+                CollectionsMarshal.SetCount(sendMessageData, startIndex + totalBytes);
+                var dstFloats = MemoryMarshal.Cast<byte, float>(CollectionsMarshal.AsSpan(sendMessageData).Slice(startIndex, totalBytes));
+                for (int i = 0; i < nSamples; i++)
                 {
-                    for (int i = 0; i < nSamples; i++)
-                    {
-                        *(float*)ptr = data[i].L;
-                        sendMessageData.AddRange(array);
-                        *(float*)ptr = data[i].R;
-                        sendMessageData.AddRange(array);
-                    }
-                }
-                else
-                {
-                    for (int i = 0; i < nSamples; i++)
-                    {
-                        *(float*)ptr = (data[i].L + data[i].R);
-                        sendMessageData.AddRange(array);
-                    }
+                    dstFloats[i] = data[i].L + data[i].R;
                 }
             }
         }

--- a/ReBuzz/NativeMachine/NativeMessage.cs
+++ b/ReBuzz/NativeMachine/NativeMessage.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Xml.Linq;
 
@@ -146,10 +147,9 @@ namespace ReBuzz.NativeMachine
 
             if (size > MessageBuffer.MaxSize)
             {
-                for (int i = 0; i < MessageBuffer.MaxSize; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, MessageBuffer.MaxSize);
+                var dst = new Span<byte>(dataRootPointer, MessageBuffer.MaxSize);
+                src.CopyTo(dst);
 
                 sendMessageDataoffset += MessageBuffer.MaxSize;
                 size = MessageBuffer.MaxSize;
@@ -158,11 +158,10 @@ namespace ReBuzz.NativeMachine
             }
             else
             {
-                for (int i = 0; i < size; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
-                
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, size);
+                var dst = new Span<byte>(dataRootPointer, size);
+                src.CopyTo(dst);
+
                 done = true;
                 sendMessageDataoffset = 0;
                 SetChannelState(ChannelState.sendlastbuffer);
@@ -275,10 +274,9 @@ namespace ReBuzz.NativeMachine
 
             if (size > MessageBuffer.MaxSize)
             {
-                for (int i = 0; i < MessageBuffer.MaxSize; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, MessageBuffer.MaxSize);
+                var dst = new Span<byte>(dataRootPointer, MessageBuffer.MaxSize);
+                src.CopyTo(dst);
 
                 sendMessageDataoffset += MessageBuffer.MaxSize;
                 size = MessageBuffer.MaxSize;
@@ -294,10 +292,9 @@ namespace ReBuzz.NativeMachine
             }
             else
             {
-                for (int i = 0; i < size; i++)
-                {
-                    dataRootPointer[i] = sendMessageData[i + sendMessageDataoffset];
-                }
+                var src = CollectionsMarshal.AsSpan(sendMessageData).Slice(sendMessageDataoffset, size);
+                var dst = new Span<byte>(dataRootPointer, size);
+                src.CopyTo(dst);
 
                 done = true;
                 sendMessageDataoffset = 0;


### PR DESCRIPTION
This PR is stacked on top of #94 — please review #94 first. Until #94 merges, this PR's diff includes both the byte-buffer copy change (from #94) AND the sample-data write change introduced here. Once #94 merges into main, this diff will automatically reduce to just the sample-data change.

`SetMessageData(Sample[], int, bool)` used a 4-byte scratch buffer and called `sendMessageData.AddRange` once per channel per sample. For an N-sample stereo message, that's 2N `AddRange` invocations on a growable `List<byte>`, each one potentially allocator-touching. Per-sample turns a bulk copy into a series of small ones.

**Stereo path** — `Sample` is `{ float L; float R; }` with no padding (no `[StructLayout]`, two consecutive float fields), so a `Sample[]` of length N has exactly the same byte representation as 8N consecutive bytes in the IPC channel. The new code uses:

```csharp
var srcBytes = MemoryMarshal.AsBytes(data.AsSpan(0, nSamples));
int startIndex = sendMessageData.Count;
CollectionsMarshal.SetCount(sendMessageData, startIndex + srcBytes.Length);
srcBytes.CopyTo(CollectionsMarshal.AsSpan(sendMessageData).Slice(startIndex, srcBytes.Length));
```

One pre-size, one vectorised copy. Replaces 2N `AddRange` calls.

**Mono path** — still needs per-sample L+R mixing, but pre-sizes the destination via `CollectionsMarshal.SetCount` and writes directly into the destination span reinterpreted as `Span<float>` via `MemoryMarshal.Cast<byte, float>`. No `AddRange` per sample, no 4-byte scratch buffer.

The `unsafe` keyword is no longer needed on the method since the new body uses managed Span types throughout — dropped from the signature.

Verified:
- Built cleanly
- Tested with a song running both an Infector native machine and a Tal Sampler VST simultaneously
- Stereo correctness specifically confirmed (TAL Sampler stereo output sounded correct, no channel swap, no distortion)
- Same test passed identically to #94's smoke test

Happy to revise. Notable points for the reviewer:
- The stereo path assumes `Sample` layout is exactly `{L, R}` with no padding. The struct definition in `BuzzGUI.Interfaces/MachineInterface/Sample.cs` matches that. If a future change to `Sample` ever adds fields or alignment, the stereo path would silently misbehave. Worth a comment in `Sample.cs` flagging the layout assumption — happy to add that in this PR if you'd like.