### PR TITLE
Use Stopwatch.GetTimestamp for performance-count timing

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1633,7 +1633,7 @@ namespace ReBuzz.Core
                     pdc.MaxEngineLockTime = 0;
                 }
 
-                long now = DateTime.UtcNow.Ticks;
+                long now = Stopwatch.GetTimestamp();
                 PerformanceCurrent.PerformanceCount += now - performanceCountTime;
                 performanceCountTime = now;
 


### PR DESCRIPTION
`ReBuzzCore.cs` used `DateTime.UtcNow.Ticks` to bracket the per-meter-update `PerformanceCount` accumulator. `DateTime.UtcNow` on modern Windows is implemented via a kernel transition; `Stopwatch.GetTimestamp` reads `QueryPerformanceCounter`, which is much cheaper.

The change also removes a latent unit mismatch. `WorkManager.cs` already uses `Stopwatch.GetTimestamp` to accumulate `EnginePerformanceCount`. Since the two fields combine into the CPU% display (`EnginePerformanceCount / PerformanceCount`), having one numerator in Stopwatch ticks and the denominator in DateTime ticks gives silently wrong readings on any hardware where `Stopwatch.Frequency != 10MHz`. On most modern Windows machines the two frequencies happen to coincide at 10MHz, so the bug was latent — but the units mismatch is real and would manifest on hardware where they differ (older systems, certain virtualisation setups). Having both in the same units is correct.

Verified:
- Built cleanly
- CPU% meter (View → CPU Monitor) reads ~5% ±1.5% on a 60-host test song
- Same reading on the dev build as on the pristine installed reference, confirming numerical equivalence on this hardware (Stopwatch.Frequency = 10MHz)

Trivial change, one line. Happy to revise.