### PR TITLE
Use foreach in PlayPatternColumnEvents to avoid O(N^2) ElementAt

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -529,9 +529,8 @@ namespace ReBuzz.Audio
                         continue;
 
                     var ces = column.GetEvents(pattern.PlayPosition, pattern.PlayPosition + nextPos);
-                    for (int j = 0; j < ces.Count(); j++)
+                    foreach (var pe in ces)
                     {
-                        var pe = ces.ElementAt(j);
                         if (column.Type == PatternColumnType.MIDI)
                         {
                             var data = pe.Value;


### PR DESCRIPTION
`PlayPatternColumnEvents` is marked `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` and runs per audio chunk during playback. The inner loop over pattern column events called `ces.Count()` each iteration and `ces.ElementAt(j)` to retrieve each event:

```csharp
for (int j = 0; j < ces.Count(); j++)
{
    var pe = ces.ElementAt(j);
    ...
}
```

`ces` is `IEnumerable<PatternEvent>` (return type of `column.GetEvents(...)`). `ElementAt` on a non-indexable IEnumerable re-enumerates from the start, making the loop O(N²) per chunk for N events. Most chunks have zero or one event, so the cost was hidden — but chunks with several events incurred quadratic work for no reason.

This PR replaces the for+ElementAt pattern with a foreach:

```csharp
foreach (var pe in ces)
{
    ...
}
```

The loop body uses only `pe`, not `j`. Same iteration order, O(N) instead of O(N²).

Verified:
- Built cleanly
- Will dogfood-test under daily-driver use before the maintainer reviews; will report back if any pattern-playback regression turns up

Happy to revise.