### PR TITLE
Avoid LINQ-allocating property accesses in UpdatePatternPositions

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -324,11 +324,12 @@ namespace ReBuzz.Audio
         internal void UpdatePatternPositions(int sampleCount)
         {
             // Clear all pattern play positions
-            foreach (var machine in buzzCore.SongCore.Machines)
+            foreach (var machine in buzzCore.SongCore.MachinesList)
             {
-                foreach (var pattern in machine.Patterns)
+                if (machine.Hidden || !machine.Ready) continue;
+                foreach (var pattern in machine.PatternsList)
                 {
-                    (pattern as PatternCore).PlayPosition = int.MinValue;
+                    pattern.PlayPosition = int.MinValue;
                 }
             }
 


### PR DESCRIPTION
`UpdatePatternPositions` runs every audio chunk during playback. It iterated `SongCore.Machines` and `machine.Patterns`, both of which are properties that allocate fresh collections per access:

```csharp
public ReadOnlyCollection<IMachine> Machines {
    get => machinesList.Where(m => !m.Hidden && m.Ready).Cast<IMachine>().ToReadOnlyCollection();
}

public ReadOnlyCollection<IPattern> Patterns {
    get { return patterns.Cast<IPattern>().ToReadOnlyCollection(); }
}
```

For a song with N managed machines this produced 1 + N fresh `ReadOnlyCollection<T>` allocations per chunk (plus the LINQ enumerators they wrap), all immediately orphaned after the foreach completed. On a 60-machine song at typical chunk sizes that's roughly 22,000 small allocations per second from this one call site.

This PR switches the iteration to use the direct list accessors that already exist on the same types — `SongCore.MachinesList` (a `List<MachineCore>`) and `machine.PatternsList` (a `List<PatternCore>`) — with an inline `(machine.Hidden || !machine.Ready)` check preserving the exact filter semantics the property previously applied.

```csharp
foreach (var machine in buzzCore.SongCore.MachinesList)
{
    if (machine.Hidden || !machine.Ready) continue;
    foreach (var pattern in machine.PatternsList)
    {
        pattern.PlayPosition = int.MinValue;
    }
}
```

The `(pattern as PatternCore)` cast drops away because `PatternsList` is already typed as `List<PatternCore>`.

Verified:
- Built cleanly
- Dogfood-tested under a complex pattern-driven session: pattern playhead advances smoothly during playback, repeated stop/restart from various positions all behave correctly, no stuck notes, no visible regression in pattern editor behaviour
- The `Hidden` filter is preserved — songs loaded from .bmx/.bmxml files set Hidden=true on some internal machines, so the filter is exercised in normal use rather than dead code

Happy to revise.