### PR TITLE
Avoid LINQ-allocating Outputs/Inputs accesses on the work path

### DIFF
--- a/ReBuzz/MachineManagement/MachineWorkInstance.cs
+++ b/ReBuzz/MachineManagement/MachineWorkInstance.cs
@@ -61,8 +61,9 @@ namespace ReBuzz.MachineManagement
                     Sample[] samples = Machine.GetStereoSamples(nSamples);
                     Machine.UpdateOutputs(samples, nSamples, false);
 
-                    foreach (var output in Machine.Outputs)
+                    foreach (var output in Machine.AllOutputs)
                     {
+                        if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                         (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
                     }
                 }
@@ -108,8 +109,9 @@ namespace ReBuzz.MachineManagement
             {
                 if (Machine.Inputs.Count == 0)
                 {
-                    foreach (var mo in Machine.Outputs)
+                    foreach (var mo in Machine.AllOutputs)
                     {
+                        if (mo.Destination.InputChannelCount == 0 || (mo.Destination as MachineCore).Hidden) continue;
                         (mo as MachineConnectionCore).ClearBuffer(nSamples);
                     }
                     return false;
@@ -128,8 +130,9 @@ namespace ReBuzz.MachineManagement
             if ((flags & MachineInfoFlags.DOES_INPUT_MIXING) == MachineInfoFlags.DOES_INPUT_MIXING)
             {
 
-                foreach (var input in Machine.Inputs)
+                foreach (var input in Machine.AllInputs)
                 {
+                    if (input.Source.OutputChannelCount == 0 || (input.Source as MachineCore).Hidden) continue;
                     var inputCore = input as MachineConnectionCore;
                     samples = inputCore.Buffer;
                     audiom.AudioInput(Machine, samples, nSamples, input.Amp / (float)0x4000, true);
@@ -148,8 +151,9 @@ namespace ReBuzz.MachineManagement
                     multiSamplesOut.Add(null);
                 }
 
-                foreach (var outConnection in Machine.Outputs)
+                foreach (var outConnection in Machine.AllOutputs)
                 {
+                    if (outConnection.Destination.InputChannelCount == 0 || (outConnection.Destination as MachineCore).Hidden) continue;
                     if (multiSamplesOutBuffers[outConnection.SourceChannel] == null)
                         multiSamplesOutBuffers[outConnection.SourceChannel] = new Sample[256];
                     multiSamplesOut[outConnection.SourceChannel] = multiSamplesOutBuffers[outConnection.SourceChannel];
@@ -174,8 +178,9 @@ namespace ReBuzz.MachineManagement
                     Machine.UpdateOutputs(multiSamplesOut, nSamples);
                 }
 
-                foreach (var output in Machine.Outputs)
+                foreach (var output in Machine.AllOutputs)
                 {
+                    if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                     var outputCore = output as MachineConnectionCore;
                     outputCore.DoTap(outputCore.Buffer, nSamples, true, buzz.GetSongTime());
                 }
@@ -210,8 +215,9 @@ namespace ReBuzz.MachineManagement
                     samples = silentBuffer;
                 }
                 Machine.UpdateOutputs(samples, nSamples);
-                foreach (var output in Machine.Outputs)
+                foreach (var output in Machine.AllOutputs)
                 {
+                    if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                     (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
                 }
             }
@@ -245,8 +251,9 @@ namespace ReBuzz.MachineManagement
                     multiSamplesOut.Add(null);
                 }
 
-                foreach (var outConnection in Machine.Outputs)
+                foreach (var outConnection in Machine.AllOutputs)
                 {
+                    if (outConnection.Destination.InputChannelCount == 0 || (outConnection.Destination as MachineCore).Hidden) continue;
                     if (multiSamplesOutBuffers[outConnection.SourceChannel] == null)
                         multiSamplesOutBuffers[outConnection.SourceChannel] = new Sample[256];
                     multiSamplesOut[outConnection.SourceChannel] = multiSamplesOutBuffers[outConnection.SourceChannel];
@@ -266,15 +273,17 @@ namespace ReBuzz.MachineManagement
                     Sample[] samples = new Sample[nSamples];
                     Machine.UpdateOutputs(samples, nSamples);
 
-                    foreach (var output in Machine.Outputs)
+                    foreach (var output in Machine.AllOutputs)
                     {
+                        if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                         (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
                     }
                 }
                 else
                 {
-                    foreach (var output in Machine.Outputs)
+                    foreach (var output in Machine.AllOutputs)
                     {
+                        if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                         var outputConn = output as MachineConnectionCore;
                         if (multiSamplesOut[outputConn.SourceChannel] != null)
                         {
@@ -306,8 +315,9 @@ namespace ReBuzz.MachineManagement
                     samples = new Sample[nSamples];
                     Machine.UpdateOutputs(samples, nSamples);
 
-                    foreach (var output in Machine.Outputs)
+                    foreach (var output in Machine.AllOutputs)
                     {
+                        if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                         (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
                     }
                 }
@@ -315,8 +325,9 @@ namespace ReBuzz.MachineManagement
                 {
                     Machine.UpdateOutputs(samples, nSamples);
 
-                    foreach (var output in Machine.Outputs)
+                    foreach (var output in Machine.AllOutputs)
                     {
+                        if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                         (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
                     }
                 }


### PR DESCRIPTION
`MachineCore.Outputs` and `MachineCore.Inputs` are properties that allocate a fresh filtered `List<IMachineConnection>` per access:

```csharp
public ReadOnlyCollection<IMachineConnection> Outputs
{
    get
    {
        List<IMachineConnection> connections = new List<IMachineConnection>();
        foreach (var output in outputs)
        {
            if (output.Destination.InputChannelCount > 0 && !(output.Destination as MachineCore).Hidden)
                connections.Add(output);
        }
        return connections.AsReadOnly();
    }
}
```

These properties are accessed eleven times in `MachineWorkInstance.cs` hot-path code — once or more per machine per chunk during playback. The sites cover `WorkMachine` bypass, `WorkMachineNative` (input mixing, multi-IO, single-IO post-work, no-input early-out), and the equivalents in `WorkMachineManaged` (multi-IO output zeroing, muted DoTap, non-muted DoTap). On a song with N machines this produces N+ fresh `List<IMachineConnection>` allocations per chunk, all immediately orphaned.

This PR swaps each foreach to iterate the direct list accessor that already exists on `MachineCore` (`AllOutputs` / `AllInputs`) with an inline filter check equivalent to what the property previously applied:

```csharp
// Outputs version:
foreach (var output in Machine.AllOutputs)
{
    if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
    // body unchanged
}

// Inputs version:
foreach (var input in Machine.AllInputs)
{
    if (input.Source.OutputChannelCount == 0 || (input.Source as MachineCore).Hidden) continue;
    // body unchanged
}
```

Same iteration semantics, zero per-access allocation. One remaining `Machine.Inputs.Count == 0` check is deliberately left for a future micro-PR — it needs a different shape of fix (boolean flag with break, rather than the inline-filter substitution used here) and isn't worth bundling.

Verified:
- Built cleanly under Release config
- Dogfood-tested across all four code-path categories the change touches:
  - Managed-machine pattern playback (a complex song with many managed machines and pattern-driven content) — plays cleanly
  - Native VST loaded as a generator, muted via a Muter machine — both work paths produce audio correctly and mute correctly
  - Machines in bypass state — routing correct (covers the WorkMachine bypass site)
  - Machines in mute state, both manually and via MIDI-driven Muter — routing correct (covers the muted branches in WorkMachineManaged)
- The `Hidden` filter is preserved at every site — songs loaded from .bmx/.bmxml files set Hidden=true on some internal machines, so the filter is exercised in normal use

Happy to revise. If a helper method (e.g. an enumerator on `MachineCore` that yields filtered connections) would be preferred over the inline check, I can refactor — went with the inline approach for minimal review surface but a cleaner abstraction is straightforward.