### PR TITLE
Eliminate remaining per-chunk allocations in MachineWorkInstance

### DIFF
--- a/ReBuzz/MachineManagement/MachineWorkInstance.cs
+++ b/ReBuzz/MachineManagement/MachineWorkInstance.cs
@@ -107,7 +107,16 @@ namespace ReBuzz.MachineManagement
 
             if (Machine.DLL.Info.Type == MachineType.Effect)
             {
-                if (Machine.Inputs.Count == 0)
+                bool hasInput = false;
+                foreach (var input in Machine.AllInputs)
+                {
+                    if (input.Source.OutputChannelCount > 0 && !(input.Source as MachineCore).Hidden)
+                    {
+                        hasInput = true;
+                        break;
+                    }
+                }
+                if (!hasInput)
                 {
                     foreach (var mo in Machine.AllOutputs)
                     {
@@ -270,7 +279,7 @@ namespace ReBuzz.MachineManagement
                 // For muted machines, call Work() but send empty buffer
                 if (Machine.IsMuted || Machine.IsSeqMute || (buzz.SongCore.SoloMode && !Machine.IsSoloed && Machine.DLL.Info.Type == MachineType.Generator))
                 {
-                    Sample[] samples = new Sample[nSamples];
+                    Sample[] samples = silentBuffer;
                     Machine.UpdateOutputs(samples, nSamples);
 
                     foreach (var output in Machine.AllOutputs)
@@ -291,7 +300,7 @@ namespace ReBuzz.MachineManagement
                         }
                         else
                         {
-                            outputConn.DoTap(new Sample[nSamples], nSamples, true, buzz.GetSongTime());
+                            outputConn.DoTap(silentBuffer, nSamples, true, buzz.GetSongTime());
                         }
                     }
                 }
@@ -312,7 +321,7 @@ namespace ReBuzz.MachineManagement
                 // For muted machines, call Work() but send empty buffer
                 if (Machine.IsMuted || Machine.IsSeqMute || (buzz.SongCore.SoloMode && !Machine.IsSoloed && Machine.DLL.Info.Type == MachineType.Generator))
                 {
-                    samples = new Sample[nSamples];
+                    samples = silentBuffer;
                     Machine.UpdateOutputs(samples, nSamples);
 
                     foreach (var output in Machine.AllOutputs)


### PR DESCRIPTION
Two remaining per-chunk allocation patterns in `MachineWorkInstance.cs` after #99 and #100 landed. Bundled together as both are small and live in the same file.

**Muted-machine Sample[] allocations (three sites).** `WorkMachineManaged` allocated a fresh `new Sample[nSamples]` per muted machine per chunk at three sites — the muted multi-IO path, a null-channel fallback inside the non-muted multi-IO branch, and the muted single-IO path. Each allocation produces ~2KB of zero-initialised data immediately handed to `UpdateOutputs` and `DoTap`, then orphaned.

These three sites now reuse the existing `silentBuffer` field (`readonly Sample[256]` declared at line 92), which is the same buffer already used by the native muted paths at `WorkMachineNative` lines 121 (`Machine.UpdateOutputs(silentBuffer, nSamples)`) and 169 (`samples = silentBuffer`). The contract relied on — that `UpdateOutputs` and `DoTap` treat their sample-buffer argument as read-only — is the same contract the native paths already depend on, so reusing the field for the managed paths is consistent. The buffer's 256-element capacity matches `nSamples` upper bound (already used as the implicit max throughout the file, e.g. `multiSamplesOutBuffers = new Sample[256][]` at line 91).

**`Machine.Inputs.Count == 0` check.** This was the one site PR #100 deliberately deferred — it needed a different fix shape from the foreach pattern used at the other eleven sites. The semantic is "does this effect have any valid input connections?" where "valid" matches the filter the `Inputs` property previously applied (`Source.OutputChannelCount > 0 && !Source.Hidden`). Now expressed as a `foreach` over `AllInputs` with an early `break` once any qualifying input is found:

```csharp
bool hasInput = false;
foreach (var input in Machine.AllInputs)
{
    if (input.Source.OutputChannelCount > 0 && !(input.Source as MachineCore).Hidden)
    {
        hasInput = true;
        break;
    }
}
if (!hasInput)
{
    // existing block unchanged
}
```

Same filter semantics, zero allocation. Early-break means the typical case (effect with at least one valid input) walks at most one input before exiting.

Net result: no remaining per-chunk allocations from these patterns in `MachineWorkInstance.cs`.

Verified:
- Built cleanly under Release config
- Dogfood-tested across the relevant code paths:
  - Mute toggled on/off on effects and generators, both manually and via MIDI-driven Muter machine
  - Multi-IO and single-IO machines both muted
  - Solo mode (which exercises the same muted branches for non-soloed generators) — only the soloed machine plays
- The `silentBuffer` contract has been operating correctly for the native muted paths since long before this change; this PR extends the same reuse to the managed paths

Happy to revise.