### PR TITLE
Avoid intermediate byte[] when appending received native bytes

### DIFF
--- a/ReBuzz/NativeMachine/NativeMessage.cs
+++ b/ReBuzz/NativeMachine/NativeMessage.cs
@@ -230,15 +230,13 @@ namespace ReBuzz.NativeMachine
                 if (state == ChannelState.replylastbuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
                     break;
                 }
                 else if (state == ChannelState.replybuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
 
                     // Request more
                     SetChannelState(ChannelState.sendbuffer);
@@ -249,8 +247,7 @@ namespace ReBuzz.NativeMachine
                 else if (state == ChannelState.sendbuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
 
                     // Request more
                     SetChannelState(ChannelState.replybuffer);
@@ -260,8 +257,7 @@ namespace ReBuzz.NativeMachine
                 else if (state == ChannelState.sendlastbuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
                     break;
                 }
             }
@@ -363,16 +359,14 @@ namespace ReBuzz.NativeMachine
                 if (state == ChannelState.replylastbuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    if (bytes.Length > 0)
-                        receaveMessageData.AddRange(bytes);
+                    if (size > 0)
+                        AppendMessageBytes(size, receaveMessageData);
                     break;
                 }
                 else if (state == ChannelState.replybuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
 
                     SetChannelState(ChannelState.sendbuffer);
 
@@ -383,8 +377,7 @@ namespace ReBuzz.NativeMachine
                 else if (state == ChannelState.sendbuffer)
                 {
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
 
                     SetChannelState(ChannelState.replybuffer);
 
@@ -395,8 +388,7 @@ namespace ReBuzz.NativeMachine
                 {
                     // Last buffer sent, so copy last part and exit loop
                     int size = GetMessageSize();
-                    byte[] bytes = ReadMessageBytes(size);
-                    receaveMessageData.AddRange(bytes);
+                    AppendMessageBytes(size, receaveMessageData);
                     break;
                 }
             }
@@ -1247,6 +1239,14 @@ namespace ReBuzz.NativeMachine
         public bool IsCallback()
         {
             return *(int*)callbackPointer == 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal unsafe void AppendMessageBytes(int size, List<byte> dst)
+        {
+            int oldCount = dst.Count;
+            CollectionsMarshal.SetCount(dst, oldCount + size);
+            new Span<byte>(dataRootPointer, size).CopyTo(CollectionsMarshal.AsSpan(dst).Slice(oldCount, size));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Mirror of #94 on the receive side. `DoReceiveReply` and `ReadMessage` both used this pattern:

```csharp
int size = GetMessageSize();
byte[] bytes = ReadMessageBytes(size);  // allocates byte[size]
receaveMessageData.AddRange(bytes);      // copies into List<byte>
```

Eight call sites across the two methods. Per native machine per chunk, each message buffer fragment allocates a fresh `byte[]` only to feed an immediate `AddRange` into `receaveMessageData`. The intermediate array is orphaned the moment AddRange completes.

This PR introduces an internal helper that goes native pointer → List<byte> directly:

```csharp
[MethodImpl(MethodImplOptions.AggressiveInlining)]
internal unsafe void AppendMessageBytes(int size, List<byte> dst)
{
    int oldCount = dst.Count;
    CollectionsMarshal.SetCount(dst, oldCount + size);
    new Span<byte>(dataRootPointer, size).CopyTo(CollectionsMarshal.AsSpan(dst).Slice(oldCount, size));
}
```

`SetCount` grows the List's backing in-place; `AsSpan().Slice(oldCount, size)` gives a writable Span over the newly-allocated region; `new Span<byte>(dataRootPointer, size).CopyTo(...)` does the single memcpy. Same `CollectionsMarshal` + `Span` shape as #94 on the send side, just running in reverse.

Seven of the eight call sites had character-identical patterns and collapse to one call. The eighth (in `ReadMessage`) had an `if (bytes.Length > 0)` guard which becomes an equivalent `if (size > 0)` — `bytes.Length` was always `size` since the byte[] was freshly allocated to that exact size.

The public `ReadMessageBytes(int size)` method is preserved unchanged. The helper is `internal` because only call sites within `NativeMessage.cs` use it.

Verified:
- Built cleanly under Release config
- Dogfood-tested with a complex song containing many native machines (Z-Plane, several PedalFM/PedalHV variants, native PCM player, plus VSTs). Played for several minutes — no audio anomalies, no dropouts, no instability
- Saved and reloaded the song twice; both reloads played correctly afterwards — exercises non-work-loop IPC paths too

Happy to revise.