### PR TITLE
perf(workmanager): interim §5 — elide per-dispatch LINQ sort + lambda…

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -67,6 +67,9 @@ namespace ReBuzz.Audio
             this.algorithm = algorithm;
             engineSettings = settings;
 
+            workOneList = WorkOneList;
+            workOneGroups = WorkOneGroups;
+
             var master = buzzCore.SongCore.MachinesList.FirstOrDefault(m => m.DLL.Info.Type == MachineType.Master);
             var masterGlobalParameters = master.ParameterGroupsList[1].ParametersList;
         }
@@ -647,24 +650,12 @@ namespace ReBuzz.Audio
                 }
                 else
                 {
+                    dispatchSamples = workSamplesCount;
                     workTasks.Clear();
 
-                    foreach (var machine in workSet.OrderByDescending(m => m.performanceLastCount))
-                    {
-                        var t = AudioEngine.TaskFactoryAudio.StartNew(() =>
-                        {
-                            if (machine.workDone)
-                                return;
-
-                            // Call work and update machine activity flag
-                            var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
-                            workInstance.TickAndWork(workSamplesCount, true);
-
-                            machine.workDone = true;
-                        });
-
-                        workTasks.Add(t);
-                    }
+                    int n = FillAndSortDesc();
+                    for (int s = 0; s < n; s++)
+                        workTasks.Add(AudioEngine.TaskFactoryAudio.StartNew(workOneGroups, sortScratch[s]));
 
                     // Wait all tasks to complete
                     Task.WaitAll(workTasks);
@@ -690,19 +681,68 @@ namespace ReBuzz.Audio
         readonly List<Task> workTasks = new List<Task>(100);
         private readonly EngineSettings engineSettings;
 
+        // Interim §5: reused scratch + cached non-capturing dispatch delegates
+        // (kills per-chunk OrderByDescending alloc and per-task display-class capture).
+        private MachineCore[] sortScratch = new MachineCore[64];
+        private int dispatchSamples;
+        private readonly Action<object> workOneList;
+        private readonly Action<object> workOneGroups;
+
+        // Copy workSet into sortScratch and stable-descending insertion-sort by
+        // performanceLastCount. Only one algorithm path runs per ReadWork (single
+        // audio thread), so a single shared scratch is safe.
+        private int FillAndSortDesc()
+        {
+            int n = workSet.Count;
+            if (sortScratch.Length < n)
+                sortScratch = new MachineCore[Math.Max(n, sortScratch.Length * 2)];
+
+            int i = 0;
+            foreach (var m in workSet)
+                sortScratch[i++] = m;
+
+            for (int a = 1; a < n; a++)
+            {
+                var key = sortScratch[a];
+                long kc = key.performanceLastCount;
+                int b = a - 1;
+                while (b >= 0 && sortScratch[b].performanceLastCount < kc)
+                {
+                    sortScratch[b + 1] = sortScratch[b];
+                    b--;
+                }
+                sortScratch[b + 1] = key;
+            }
+            return n;
+        }
+
+        // HandleWorkList body: work only; caller sets workDone on the dispatch thread.
+        private void WorkOneList(object state)
+        {
+            var machine = (MachineCore)state;
+            var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
+            workInstance.TickAndWork(dispatchSamples, true);
+        }
+
+        // Groups body: guard + set workDone inside, matching the original lambda.
+        private void WorkOneGroups(object state)
+        {
+            var machine = (MachineCore)state;
+            if (machine.workDone)
+                return;
+            var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
+            workInstance.TickAndWork(dispatchSamples, true);
+            machine.workDone = true;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         void HandleWorkList(int numRead)
         {
+            dispatchSamples = numRead;
             workTasks.Clear();
             foreach (var machine in workSet)
             {
-                var t = AudioEngine.TaskFactoryAudio.StartNew(() =>
-                {
-                    // Call work and update machine activity flag
-                    var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
-                    workInstance.TickAndWork(numRead, true);
-                });
-                workTasks.Add(t);
+                workTasks.Add(AudioEngine.TaskFactoryAudio.StartNew(workOneList, machine));
                 machine.workDone = true;
             }
 
@@ -789,8 +829,10 @@ namespace ReBuzz.Audio
                     break;
                 }
 
-                foreach (var machine in workSet.OrderByDescending(m => m.performanceLastCount))
+                int n = FillAndSortDesc();
+                for (int s = 0; s < n; s++)
                 {
+                    var machine = sortScratch[s];
                     // Add work instances to be processed
                     var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
                     workEngine.AddWork(workInstance);


### PR DESCRIPTION
# PR: remove per-dispatch LINQ + lambda allocations in the multithreaded work path

**File:** `ReBuzz/Audio/WorkManager.cs` · **Risk:** low · **Hot path:** audio, multithreaded modes only

## What

Two per-dispatch allocation sources in the multithreaded work scheduler, eliminated
without changing dispatch behaviour:

1. **`OrderByDescending` → reused-scratch insertion sort.** The "process heaviest
   machines first" sort in `HandleWorkAlgorithmGroups` and `HandleWorkAlgorithm2`
   allocated a LINQ enumerator + sort buffer every group iteration. Replaced with an
   in-place stable insertion sort over a reused `MachineCore[]` scratch (the work set is
   small). The sort is scheduling priority only — it does not affect the mix order (fixed
   by the connection graph), so output is unchanged.

2. **Capturing `Task` lambdas → cached non-capturing delegates.** In `HandleWorkList` and
   the `HandleWorkAlgorithmGroups` dispatch, `TaskFactoryAudio.StartNew(() => …)` captured
   `machine` + the sample count, allocating a compiler display class **per task**. Replaced
   with two cached `Action<object>` delegates; the machine is passed via `StartNew`'s state
   argument (reference type, no boxing) and the per-call sample count via a field.
   `machine.workDone` set/guard semantics are preserved exactly per path (the two paths
   differ — `HandleWorkList` sets `workDone` on the dispatch thread with no guard; the
   Groups path guards and sets inside).

## Why

In multithreaded mode at ~30 machines / ~187 chunks-per-second, the lambda capture alone
was ~5,600 display-class allocations/sec, plus the per-iteration LINQ enumerator + sort
buffer — all per-chunk Gen0 garbage on the audio hot path. This removes it. Pure
allocation reduction; no behavioural change.

## Scope / safety

- `WorkManager.cs` only. Multithreaded paths only (single-thread mode doesn't hit this).
- Builds on the already-merged work-scheduler hoist (the reused `workTasks` field /
  `workSet` HashSet); this removes the two allocation sources that hoist didn't cover.
- `HandleWorkRecursive`'s per-input-edge `Task` allocation is intentionally **not** touched
  (different shape; out of scope here).

## Testing

Built and run on a real session (managed + native machines) in multithreaded mode; no
behavioural change in playback. Per-PR CPU A/B sits at/below the noise floor as expected
for an allocation-only change — the win is reduced Gen0 pressure in MT mode, not average
CPU; it shows up cumulatively rather than per-PR.

## Note

Independent of a separate, larger discussion I'm opening as an issue about splitting
`AudioLock` into a reader/writer lock — that one is unrelated to this and far higher
blast-radius. This PR stands on its own.
