### PR TITLE
Remove redundant AudioLock in save/open/new (SkipAudio already quiesces audio)

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1288,11 +1288,11 @@ namespace ReBuzz.Core
                 NewSong();
 
                 SkipAudio = true;
-                lock (AudioLock)
-                {   
+                //lock (AudioLock)
+                //{
                     bool playing = Playing;
                     Playing = false;
-                }
+                //}
 
                 IReBuzzFile bmxFile = GetReBuzzFile(filename);
 
@@ -1411,8 +1411,8 @@ namespace ReBuzz.Core
             SkipAudio = true;
             //AudioEngine.Stop();
 
-            lock (AudioLock)
-            {
+            //lock (AudioLock)
+            //{
                 try
                 {
                     file.Save(filename);
@@ -1421,7 +1421,7 @@ namespace ReBuzz.Core
                 {
                     Utils.MessageBox("Error saving file " + filename + "\n\n" + ex, "Error saving file.");
                 }
-            }
+            //}
 
             //AudioEngine.Play();
             SkipAudio = false;
@@ -1981,8 +1981,8 @@ namespace ReBuzz.Core
             MidiControllerAssignments.ClearControllerBindings();
 
             DeleteBackup();
-            lock (AudioLock)
-            {
+            //lock (AudioLock)
+            //{
                 AudioEngine.ClearAudioBuffer();
 
                 // Remove groups
@@ -2049,7 +2049,7 @@ namespace ReBuzz.Core
 
                 Speed = 0;
                 FileEvent?.Invoke(FileEventType.Close, "Done.", null);
-            }
+            //}
 
             // Center Master position
             List<Tuple<IMachine, Tuple<float, float>>> moveList = new List<Tuple<IMachine, Tuple<float, float>>>


### PR DESCRIPTION
Follow-up to the discussion in #104.

These three file/lifecycle methods set `SkipAudio = true` before taking `AudioLock`,
so the audio fill is already short-circuited by the time the body runs — the lock is a
redundant inner guard:

- `SaveSongFile` — `SkipAudio = true` before the lock; body is just `file.Save(...)`.
- `OpenSongFile` — calls `NewSong()`, sets `SkipAudio = true`; lock wrapped only a
  `Playing` flag flip (load happens outside it).
- `NewSong` — `SkipAudio = true; Playing = false` at the top, before the teardown lock.

The `lock (AudioLock)` lines are left commented rather than deleted, in case they're
wanted back later.

Scope notes:
- `SkipAudio` is left in place — it's what actually quiesces audio here; removing it too
  is a separate, more load-bearing change.
- `EndImport` is left as-is — unlike these three it takes the lock without setting
  `SkipAudio` first, so its lock isn't redundant on the same reasoning and wants its own look.

Testing: manual exercise (couldn't run ReBuzzTests locally — unrelated csproj build-target
issue). Exercised save / new / open during playback at RME 256 / ReBuzz ASIO 1536 on two
songs (a 2-machine song and a ~150-machine song). No crashes, hangs, or corruption; clean
teardown on new/open; clean save with headroom. The only artifact was a brief gap saving
the heavy song, which is already at the dropout floor at those settings before any save —
read as saturation rather than the lock removal, but flagging it as an observation.