### PR TITLE
Remove now-redundant SkipAudio from save/open/new

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1287,7 +1287,7 @@ namespace ReBuzz.Core
                 DeleteBackup();
                 NewSong();
 
-                SkipAudio = true;
+                //SkipAudio = true;
                 //lock (AudioLock)
                 //{
                     bool playing = Playing;
@@ -1311,7 +1311,7 @@ namespace ReBuzz.Core
                     userMessages.Error(e.InnerException == null ? e.Message : e.InnerException.Message, "Error loading " + filename, e);
                     bmxFile.EndFileOperation(false);
                     NewSong();
-                    SkipAudio = false;
+                    //SkipAudio = false;
                     return;
                 }
 
@@ -1331,7 +1331,7 @@ namespace ReBuzz.Core
                 }
                 SongCore.PlayPosition = 0;
 
-                SkipAudio = false;
+                //SkipAudio = false;
                 //AudioEngine.Play();
 
                 dispatcher.BeginInvoke(() =>
@@ -1408,7 +1408,7 @@ namespace ReBuzz.Core
 
             file.SetSubSections(ss);
 
-            SkipAudio = true;
+            //SkipAudio = true;
             //AudioEngine.Stop();
 
             //lock (AudioLock)
@@ -1424,7 +1424,7 @@ namespace ReBuzz.Core
             //}
 
             //AudioEngine.Play();
-            SkipAudio = false;
+            //SkipAudio = false;
             Modified = false;
         }
 
@@ -1971,7 +1971,7 @@ namespace ReBuzz.Core
         // Clean up song 
         internal void NewSong()
         {
-            SkipAudio = true;
+            //SkipAudio = true;
             Playing = false;
             InfoText = "";
 
@@ -2071,7 +2071,7 @@ namespace ReBuzz.Core
             GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
             GC.Collect();
             GC.WaitForFullGCComplete();
-            SkipAudio = false;
+            //SkipAudio = false;
         }
 
 

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1288,11 +1288,11 @@ namespace ReBuzz.Core
                 NewSong();
 
                 SkipAudio = true;
-                lock (AudioLock)
-                {   
+                //lock (AudioLock)
+                //{
                     bool playing = Playing;
                     Playing = false;
-                }
+                //}
 
                 IReBuzzFile bmxFile = GetReBuzzFile(filename);
 
@@ -1411,8 +1411,8 @@ namespace ReBuzz.Core
             SkipAudio = true;
             //AudioEngine.Stop();
 
-            lock (AudioLock)
-            {
+            //lock (AudioLock)
+            //{
                 try
                 {
                     file.Save(filename);
@@ -1421,7 +1421,7 @@ namespace ReBuzz.Core
                 {
                     Utils.MessageBox("Error saving file " + filename + "\n\n" + ex, "Error saving file.");
                 }
-            }
+            //}
 
             //AudioEngine.Play();
             SkipAudio = false;
@@ -1981,8 +1981,8 @@ namespace ReBuzz.Core
             MidiControllerAssignments.ClearControllerBindings();
 
             DeleteBackup();
-            lock (AudioLock)
-            {
+            //lock (AudioLock)
+            //{
                 AudioEngine.ClearAudioBuffer();
 
                 // Remove groups
@@ -2049,7 +2049,7 @@ namespace ReBuzz.Core
 
                 Speed = 0;
                 FileEvent?.Invoke(FileEventType.Close, "Done.", null);
-            }
+            //}
 
             // Center Master position
             List<Tuple<IMachine, Tuple<float, float>>> moveList = new List<Tuple<IMachine, Tuple<float, float>>>


### PR DESCRIPTION
Follow-up to #105 (and the discussion in #104). Stacks on #105 — if that
merges first, this rebases to just the SkipAudio change.

#105 removed the redundant `AudioLock` in `SaveSongFile` / `OpenSongFile` /
`NewSong`. With the lock gone, the `SkipAudio = true/false` brackets in those
three methods are the only remaining audio-quiescence there — and testing
shows they're no longer needed: audio plays through save and tears
down/rebuilds cleanly on new/open without them.

Removes the `SkipAudio` set/clear in all three (commented, matching #105's
style; the `SkipAudio` field and its other uses are untouched).

Testing (two machines):
- @wasteddesign confirmed save without audio hiccups after removing SkipAudio.
- My side: removed SkipAudio from save/open/new, then exercised File→New and
  File→Open a different song during playback, ~10 cycles each, on a heavy
  ~150-machine song at RME 256 (the low-latency stress case). No crashes,
  hangs, or corruption — the teardown paths rebuild cleanly without quiescence.
- Honest caveat: a teardown race would be timing-dependent, so ~20 stressed
  teardowns rules out a common race but not a rare one. Clean on two separate
  machines is reasonable evidence.

Manual exercise only — couldn't run ReBuzzTests locally (unrelated csproj
build-target issue).

Scope: `EndImport` is deliberately left alone — it takes `AudioLock` without
setting `SkipAudio` first, so it's not on this save/open/new quiescence pattern
and wants its own review.