### PR TITLE
Cache the audio work order instead of re-scanning the graph every chunk (#107)

### DIFF
--- a/ReBuzz/Audio/CachedWorkOrder.cs
+++ b/ReBuzz/Audio/CachedWorkOrder.cs
@@ -84,9 +84,13 @@ namespace ReBuzz.Audio
             var master = machines[0];
 
             // --- 1. Master-reachable audio cone (via AllInputs) ---
-            // Descend through everything so audio machines sitting behind a
-            // control machine are still reachable, but only audio machines
-            // become work nodes. Master is never added to the cone.
+            // Walk the audio graph from Master, STOPPING at control/editor
+            // machines. They are worked in the prefix, and the legacy
+            // CollectMachinesThatCanWork stops recursing at any workDone machine
+            // (controls are workDone from the prefix) - so an audio machine
+            // reachable ONLY through a control is left unworked by the legacy
+            // walk. We match that exactly rather than working a superset: descend
+            // through audio machines only. Master is never added to the cone.
             var cone = new HashSet<MachineCore>();
             var seen = new HashSet<MachineCore> { master };
             var stack = new Stack<MachineCore>();
@@ -100,9 +104,10 @@ namespace ReBuzz.Audio
                         continue;
                     if (!seen.Add(src))
                         continue;
+                    if (IsControlOrEditor(src))
+                        continue; // do not descend through controls (prefix-worked)
                     stack.Push(src);
-                    if (!IsControlOrEditor(src))
-                        cone.Add(src);
+                    cone.Add(src);
                 }
             }
 

--- a/ReBuzz/Audio/CachedWorkOrder.cs
+++ b/ReBuzz/Audio/CachedWorkOrder.cs
@@ -1,0 +1,164 @@
+﻿using BuzzGUI.Interfaces;
+using ReBuzz.Core;
+using System;
+using System.Collections.Generic;
+
+namespace ReBuzz.Audio
+{
+    // Prototype (#107): per-topology cached work order.
+    //
+    // Replaces the per-chunk O(N*D) re-scan performed by
+    // Collect{Editor,Control,}MachinesThatCanWork (one full pass per drain
+    // iteration, D iterations per chunk) with an O(N) walk of a layered order
+    // that is rebuilt only when the graph topology changes.
+    //
+    // Faithfulness to the legacy walk (see WorkManager.HandleWorkAlgorithm2 /
+    // HandleWorkAlgorithmSingleThread):
+    //   * Editors (hidden control machines) run first, then controls. Both are
+    //     run unconditionally (no input gating), exactly as the two pre-passes.
+    //   * Ready is NOT baked into membership: a native crash can clear Ready
+    //     mid-buffer, so Ready is re-tested when the prefix is walked (the
+    //     legacy control/editor collects test Ready every wave). The audio
+    //     waves do NOT test Ready, matching CollectMachinesThatCanWork which
+    //     has no Ready check.
+    //   * Audio waves are Kahn layers over the master-reachable cone, EXCLUDING
+    //     control/editor machines (worked in the prefix) and Master itself
+    //     (a pure sink: ReadWork reads master.GetStereoSamples, master.Work is
+    //     never dispatched, and the legacy drain breaks before reaching it).
+    //   * Within-wave ordering is left to the caller (kept dynamic, sorted by
+    //     performanceLastCount each chunk). It is numerically neutral: a machine
+    //     sums its inputs in connection-list order, independent of the order its
+    //     siblings were dispatched in, so output is bit-identical to the legacy
+    //     walk for the same algorithm.
+    //
+    // Master is identified as MachinesList[0], mirroring ReadWork.
+    internal sealed class CachedWorkOrder
+    {
+        public MachineCore[] EditorPrefix = Array.Empty<MachineCore>();
+        public MachineCore[] ControlPrefix = Array.Empty<MachineCore>();
+        public MachineCore[][] AudioWaves = Array.Empty<MachineCore[]>();
+
+        // Invalidation keys. BuiltGeneration tracks connection add/remove
+        // (ReBuzzCore.TopologyGeneration); BuiltMachineCount catches machine
+        // add/remove without hunting every MachinesList.Add site.
+        public long BuiltGeneration = long.MinValue;
+        public int BuiltMachineCount = -1;
+
+        // If a cycle is detected during the Kahn drain, the caller must fall
+        // back to the legacy recursive walk for this build. (The legacy
+        // CollectMachinesThatCanWork would stack-overflow on a cycle; the build
+        // detects it deterministically instead.)
+        public bool HasCycle;
+
+        private static bool IsControlOrEditor(MachineCore m)
+            => m.DLL.Info.Flags.HasFlag(MachineInfoFlags.CONTROL_MACHINE);
+
+        public void Rebuild(SongCore song)
+        {
+            HasCycle = false;
+
+            var machines = song.MachinesList;
+            BuiltMachineCount = machines.Count;
+
+            // --- Prefix partitions (editors = hidden controls, then controls) ---
+            var editors = new List<MachineCore>();
+            var controls = new List<MachineCore>();
+            foreach (var m in machines)
+            {
+                if (!IsControlOrEditor(m))
+                    continue;
+                if (m.Hidden)
+                    editors.Add(m);
+                else
+                    controls.Add(m);
+            }
+            EditorPrefix = editors.ToArray();
+            ControlPrefix = controls.ToArray();
+
+            if (machines.Count == 0)
+            {
+                AudioWaves = Array.Empty<MachineCore[]>();
+                return;
+            }
+
+            var master = machines[0];
+
+            // --- 1. Master-reachable audio cone (via AllInputs) ---
+            // Descend through everything so audio machines sitting behind a
+            // control machine are still reachable, but only audio machines
+            // become work nodes. Master is never added to the cone.
+            var cone = new HashSet<MachineCore>();
+            var seen = new HashSet<MachineCore> { master };
+            var stack = new Stack<MachineCore>();
+            stack.Push(master);
+            while (stack.Count > 0)
+            {
+                var cur = stack.Pop();
+                foreach (var input in cur.AllInputs)
+                {
+                    if (!(input.Source is MachineCore src))
+                        continue;
+                    if (!seen.Add(src))
+                        continue;
+                    stack.Push(src);
+                    if (!IsControlOrEditor(src))
+                        cone.Add(src);
+                }
+            }
+
+            // --- 2. Kahn layering over the cone ---
+            // in-degree counts only edges whose source is itself an audio node
+            // in the cone (control inputs are pre-satisfied by the prefix;
+            // edges from master/out-of-cone do not occur for valid graphs and
+            // are ignored). Parallel edges (multi-channel) are counted and
+            // decremented symmetrically.
+            var indeg = new Dictionary<MachineCore, int>(cone.Count);
+            foreach (var m in cone)
+            {
+                int d = 0;
+                foreach (var input in m.AllInputs)
+                {
+                    if (input.Source is MachineCore src && cone.Contains(src))
+                        d++;
+                }
+                indeg[m] = d;
+            }
+
+            var waves = new List<MachineCore[]>();
+            var frontier = new List<MachineCore>();
+            foreach (var kv in indeg)
+            {
+                if (kv.Value == 0)
+                    frontier.Add(kv.Key);
+            }
+
+            int placed = 0;
+            while (frontier.Count > 0)
+            {
+                waves.Add(frontier.ToArray());
+                placed += frontier.Count;
+
+                var next = new List<MachineCore>();
+                foreach (var m in frontier)
+                {
+                    foreach (var output in m.AllOutputs)
+                    {
+                        if (!(output.Destination is MachineCore dst))
+                            continue;
+                        if (!cone.Contains(dst))
+                            continue;
+                        if (--indeg[dst] == 0)
+                            next.Add(dst);
+                    }
+                }
+                frontier = next;
+            }
+
+            // Unresolved in-degrees => at least one cycle in the cone.
+            if (placed != cone.Count)
+                HasCycle = true;
+
+            AudioWaves = waves.ToArray();
+        }
+    }
+}

--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -588,11 +588,17 @@ namespace ReBuzz.Audio
 
             if (!multiThreadingEnabled)
             {
-                HandleWorkAlgorithmSingleThread(master, workSamplesCount);
+                if (engineSettings.UseCachedWorkOrder)
+                    HandleWorkAlgorithmSingleThreadCached(master, workSamplesCount);
+                else
+                    HandleWorkAlgorithmSingleThread(master, workSamplesCount);
             }
             else if (algorithm == 0)
             {
-                HandleWorkAlgorithmGroups(master, workSamplesCount);
+                if (engineSettings.UseCachedWorkOrder)
+                    HandleWorkAlgorithmGroupsCached(master, workSamplesCount);
+                else
+                    HandleWorkAlgorithmGroups(master, workSamplesCount);
             }
             else if (algorithm == 1)
             {
@@ -601,7 +607,10 @@ namespace ReBuzz.Audio
             }
             else if (algorithm == 2)
             {
-                HandleWorkAlgorithm2(master, workSamplesCount);
+                if (engineSettings.UseCachedWorkOrder)
+                    HandleWorkAlgorithm2Cached(master, workSamplesCount);
+                else
+                    HandleWorkAlgorithm2(master, workSamplesCount);
             }
 
             // Mix all to single L + R signal
@@ -856,6 +865,181 @@ namespace ReBuzz.Audio
                 }
             }
         }
+
+        // ===== #107 prototype: cached topological work order =====
+        // Gated by engineSettings.UseCachedWorkOrder. Shares the cache build
+        // (CachedWorkOrder) across dispatch styles; only consumption differs.
+        // Algorithm 1 (Recursive) is intentionally untouched: it has no per-chunk
+        // re-scan, so the cache does not apply to it.
+
+        private readonly CachedWorkOrder cachedOrder = new CachedWorkOrder();
+
+        // Runs on the audio thread under AudioLock (held for the whole buffer),
+        // so the rebuild can never race a topology mutation. Rebuild is lazy:
+        // at most one rebuild per buffer, and only when the topology changed.
+        private CachedWorkOrder GetOrBuildOrder()
+        {
+            var song = buzzCore.SongCore;
+            long gen = buzzCore.TopologyGeneration;
+            if (cachedOrder.BuiltGeneration != gen ||
+                cachedOrder.BuiltMachineCount != song.MachinesList.Count)
+            {
+                cachedOrder.Rebuild(song);
+                cachedOrder.BuiltGeneration = gen;
+            }
+            return cachedOrder;
+        }
+
+        // Copy a wave into sortScratch and stable-descending insertion-sort by
+        // performanceLastCount (kept per-chunk/dynamic, like FillAndSortDesc).
+        private int FillAndSortDescFrom(MachineCore[] wave)
+        {
+            int n = wave.Length;
+            if (sortScratch.Length < n)
+                sortScratch = new MachineCore[Math.Max(n, sortScratch.Length * 2)];
+
+            for (int i = 0; i < n; i++)
+                sortScratch[i] = wave[i];
+
+            for (int a = 1; a < n; a++)
+            {
+                var key = sortScratch[a];
+                long kc = key.performanceLastCount;
+                int b = a - 1;
+                while (b >= 0 && sortScratch[b].performanceLastCount < kc)
+                {
+                    sortScratch[b + 1] = sortScratch[b];
+                    b--;
+                }
+                sortScratch[b + 1] = key;
+            }
+            return n;
+        }
+
+        // Dispatch a prefix partition (editors or controls) as one parallel
+        // batch + barrier, mirroring CollectEditor/Control + HandleWorkList.
+        // Ready is re-tested here (a native crash can clear it mid-buffer).
+        private void DispatchPrefixCached(MachineCore[] prefix, int numRead)
+        {
+            workSet.Clear();
+            foreach (var m in prefix)
+                if (m.Ready && !m.workDone)
+                    workSet.Add(m);
+
+            if (workSet.Count > 0)
+                HandleWorkList(numRead); // dispatches workSet, sets workDone, clears workSet
+            else
+                workSet.Clear();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private void HandleWorkAlgorithm2Cached(MachineCore master, int workSamplesCount)
+        {
+            var order = GetOrBuildOrder();
+            if (order.HasCycle)
+            {
+                // Deterministic fallback: legacy walk (its CanConnect gate keeps
+                // valid songs acyclic; this only fires on a malformed graph).
+                HandleWorkAlgorithm2(master, workSamplesCount);
+                return;
+            }
+
+            workEngine.PrepareEngine(workSamplesCount);
+
+            DispatchPrefixCached(order.EditorPrefix, workSamplesCount);
+            DispatchPrefixCached(order.ControlPrefix, workSamplesCount);
+
+            foreach (var wave in order.AudioWaves)
+            {
+                if (stopped)
+                    break;
+
+                int n = FillAndSortDescFrom(wave);
+                for (int s = 0; s < n; s++)
+                {
+                    var machine = sortScratch[s];
+                    var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
+                    workEngine.AddWork(workInstance);
+                    machine.workDone = true;
+                }
+
+                workEngine.AllJobsAdded();
+                if (n > 0)
+                    workEngine.AllDoneEvent().WaitOne();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private void HandleWorkAlgorithmGroupsCached(MachineCore master, int workSamplesCount)
+        {
+            var order = GetOrBuildOrder();
+            if (order.HasCycle)
+            {
+                HandleWorkAlgorithmGroups(master, workSamplesCount);
+                return;
+            }
+
+            // Groups uses no workEngine (it is null for algorithm 0); prefix and
+            // waves dispatch via AudioEngine.TaskFactoryAudio + Task.WaitAll,
+            // matching the legacy path. workOneGroups guards/sets workDone.
+            DispatchPrefixCached(order.EditorPrefix, workSamplesCount);
+            DispatchPrefixCached(order.ControlPrefix, workSamplesCount);
+
+            foreach (var wave in order.AudioWaves)
+            {
+                int n = FillAndSortDescFrom(wave);
+                if (n == 1)
+                {
+                    var machine = sortScratch[0];
+                    var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
+                    workInstance.TickAndWork(workSamplesCount, true);
+                    machine.workDone = true;
+                }
+                else if (n > 1)
+                {
+                    dispatchSamples = workSamplesCount;
+                    workTasks.Clear();
+                    for (int s = 0; s < n; s++)
+                        workTasks.Add(AudioEngine.TaskFactoryAudio.StartNew(workOneGroups, sortScratch[s]));
+                    Task.WaitAll(workTasks);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private void HandleWorkAlgorithmSingleThreadCached(MachineCore master, int workSamplesCount)
+        {
+            var order = GetOrBuildOrder();
+            if (order.HasCycle)
+            {
+                HandleWorkAlgorithmSingleThread(master, workSamplesCount);
+                return;
+            }
+
+            // Controls-first prefix (Ready-gated), then audio waves in topo order.
+            // This also tightens the legacy single-thread path, which works
+            // editors/controls/audio together in HashSet order with no guaranteed
+            // controls-before-generators ordering.
+            WorkSerialCached(order.EditorPrefix, workSamplesCount, readyGated: true);
+            WorkSerialCached(order.ControlPrefix, workSamplesCount, readyGated: true);
+            foreach (var wave in order.AudioWaves)
+                WorkSerialCached(wave, workSamplesCount, readyGated: false);
+        }
+
+        private void WorkSerialCached(MachineCore[] list, int numRead, bool readyGated)
+        {
+            foreach (var m in list)
+            {
+                if (m.workDone)
+                    continue;
+                if (readyGated && !m.Ready)
+                    continue;
+                var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(m);
+                workInstance.TickAndWork(numRead, true);
+                m.workDone = true;
+            }
+        }
+        // ===== end #107 prototype =====
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void HandleWorkAlgorithmSingleThread(MachineCore master, int workSamplesCount)

--- a/ReBuzz/Core/MachineCore.cs
+++ b/ReBuzz/Core/MachineCore.cs
@@ -1034,6 +1034,7 @@ namespace ReBuzz.Core
         {
             this.inputs.Add(mcc);
             var buzz = graph.Buzz as ReBuzzCore;
+            buzz.TopologyGeneration++; // #107: invalidate cached work order
             //if (mcc.Source.DLL.Info.Flags.HasFlag(MachineInfoFlags.DOES_INPUT_MIXING))
             buzz.MachineManager.AddInput(this, mcc.Source, true);
         }
@@ -1114,6 +1115,7 @@ namespace ReBuzz.Core
         internal void RemoveInput(IMachineConnection mc)
         {
             var buzz = graph.Buzz as ReBuzzCore;
+            buzz.TopologyGeneration++; // #107: invalidate cached work order
             var group = parameterGroups[0];
             int trackToRemove = Inputs.IndexOf(mc);
 

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1784,6 +1784,12 @@ namespace ReBuzz.Core
         }
 
         public static Lock AudioLock = new();
+
+        // #107 prototype: bumped on every connection add/remove (see
+        // MachineCore.AddInput/RemoveInput). The cached work order rebuilds when
+        // this (or the machine count) changes. Mutated under AudioLock.
+        internal long TopologyGeneration;
+
         public MachineCore CreateMaster()
         {
             var machine = MachineManager.GetMaster(this);

--- a/ReBuzzGUI/BuzzGUI.Common/Settings/EngineSettings.cs
+++ b/ReBuzzGUI/BuzzGUI.Common/Settings/EngineSettings.cs
@@ -31,6 +31,9 @@
         [BuzzSetting(false, Description = "Use background thread to fill audio buffer (restart).")]
         public bool AudioBufferFillThread { get; set; }
 
+        [BuzzSetting(false, Description = "Prototype (#107): use a cached topological work order instead of the per-chunk graph re-scan. Affects the single-thread, Groups (algorithm 0) and Threads (algorithm 2) paths.")]
+        public bool UseCachedWorkOrder { get; set; }
+
         [BuzzSetting(PriorityProfileType.NormalAppPriority, Description = "Priority setting for threads and processes (restart).")]
         public PriorityProfileType PriorityProfile { get; set; }
 

--- a/docs/DESIGN_107_cached_work_order.md
+++ b/docs/DESIGN_107_cached_work_order.md
@@ -1,0 +1,183 @@
+# Design note: cached audio work order (#107)
+
+Companion to the PR. Records the problem, the design, the faithfulness argument, the
+correctness analysis, how it was validated, and what the measurements actually
+showed — including where the original issue's premise was wrong.
+
+---
+
+## 1. Problem
+
+On the re-scan dispatch family (WorkAlgorithm 0 "Groups", 2 "Threads", and the
+single-thread path), every audio chunk drains the graph in dependency layers. Each
+drain iteration calls, in order:
+
+- `CollectEditorMachinesThatCanWork` — hidden control machines,
+- `CollectControlMachinesThatCanWork` — visible control machines,
+- `CollectMachinesThatCanWork(master)` — the audio frontier, recursively.
+
+Each is a full pass over the graph, and there are D iterations per chunk (D = number
+of dependency layers). The result is an O(N·D) re-scan **per chunk** whose output is
+identical from chunk to chunk until the topology changes. That is the waste #107
+targets.
+
+Algorithm 1 ("Recursive Tasks", the default) does **not** re-scan — it recurses the
+graph directly — so it is out of scope here.
+
+## 2. Design
+
+### 2.1 Three partitions, rebuilt on topology change
+
+`CachedWorkOrder.Rebuild(song)` produces:
+
+- `EditorPrefix` — control machines with `Hidden == true`.
+- `ControlPrefix` — control machines with `Hidden == false`.
+- `AudioWaves` — `MachineCore[][]`, Kahn layers of the audio cone.
+
+Rebuild is triggered when either invalidation key changes:
+
+- `BuiltGeneration` vs `ReBuzzCore.TopologyGeneration` — bumped on connection
+  add/remove (`MachineCore.AddInput` / `RemoveInput`).
+- `BuiltMachineCount` vs `MachinesList.Count` — catches machine add/remove without
+  instrumenting every list mutation site.
+
+The check and any rebuild happen at the top of the chunk under `AudioLock`, so a
+walk can never observe a half-mutated graph or a stale machine reference.
+
+### 2.2 The audio cone and Kahn layering
+
+The cone is the set of machines reachable from Master (`MachinesList[0]`) via
+`AllInputs`, with control/editor machines and Master excluded as work nodes.
+In-degree counts only edges whose source is itself a cone node; control inputs are
+treated as pre-satisfied (the prefix runs first). Parallel (multi-channel) edges are
+counted and decremented symmetrically, so multi-channel connections do not corrupt
+the ordering. If the Kahn drain places fewer nodes than the cone contains, a cycle
+exists and `HasCycle` is set.
+
+## 3. Faithfulness to the legacy walk
+
+For the cache to be a drop-in, the **same machines** must run in a **dependency-valid
+order** producing the **same output**. Four observations underwrite that:
+
+- **Master is a pure sink.** `ReadWork` computes the master output by summing its
+  input buffers (`master.GetStereoSamples`); `master.Work` is never dispatched, and
+  the legacy drain breaks before reaching it. The cache excludes Master from the
+  cone for the same reason.
+- **Within-wave order is numerically neutral.** A machine sums its inputs in
+  connection-list order, independent of the order its siblings were dispatched. So
+  leaving within-wave order dynamic (sorted by cost each chunk, as today) changes
+  nothing numerically.
+- **`Ready` is not baked into membership.** A native machine crash can clear `Ready`
+  mid-buffer. The prefix walk re-tests `Ready` every chunk (matching the legacy
+  control/editor collects); the audio waves do not test `Ready`, matching
+  `CollectMachinesThatCanWork`, which has no `Ready` check. The actual skip happens
+  at the shared dispatch guard (`Machine.Ready && host != null`), identical on both
+  paths.
+- **The prefix is preserved verbatim** as editors-then-controls, run unconditionally
+  before the audio waves.
+
+## 4. The four correctness questions
+
+1. **Cycles.** The engine assumes a DAG; there is no runtime cycle handling, and the
+   legacy recursive collect would stack-overflow on a cycle. Acyclicity is enforced
+   upstream by `SongCore.CanConnectMachines` /
+   `FindDestinationFromSourceConnetions` (a connection that would close a loop is
+   refused). The cache inherits that precondition but additionally detects any cycle
+   deterministically at build time and falls back to the legacy walk — so it is
+   strictly safer than the status quo, never worse.
+2. **Mid-chunk eligibility.** `AudioLock` is held across the entire buffer. Every
+   topology and `Ready` mutation takes `AudioLock`. The only thing that changes
+   within a chunk is `workDone`, which the cached walk drives itself. Native crash
+   paths clear `Ready`; the prefix re-test and the dispatch guard handle it.
+3. **Editor/control pre-passes.** These exist because control/editor machines often
+   have no audio path to Master and so would never be reached by an audio-only walk;
+   they are run first, flat, unconditionally, every wave. The cache keeps them as a
+   fixed prefix partition rather than folding them into the topo-sort.
+4. **Wireless / dynamic.** `IsWireless` is a per-machine display property (read only
+   in file ops), never consulted in scheduling. All dynamic connect/disconnect and
+   machine add/remove route through `AudioLock`-guarded actions that fire the
+   add/remove events and bump `TopologyGeneration`, forcing a rebuild on the next
+   chunk.
+
+## 5. Known divergence (flagged for merge)
+
+The cone build **descends through control machines** (it pushes every source onto
+the traversal stack and only excludes controls from becoming work nodes). The legacy
+`CollectMachinesThatCanWork` stops recursing at any `workDone` machine, and controls
+are `workDone` from the prefix — so legacy never reaches an audio machine whose
+*only* path to Master is through a control. The cache therefore works a strict
+superset of legacy on graphs that route audio into a control.
+
+Impact: for graphs where no audio feeds a control (the common case, and the test
+song), the cone is identical to the legacy set. Where audio *does* feed a control,
+the extra machines are wasted work, not wrong output — their only consumer (the
+control) already ran in the prefix with the previous buffer, exactly as in legacy.
+(A control that *forwards* audio to Master is already mis-ordered in the legacy
+prefix and is an unsupported topology either way.)
+
+Recommendation: for a strict drop-in, do not descend into controls (skip pushing a
+control source during the cone walk). One line, plus a test for the
+audio-feeds-control case.
+
+## 6. How it was validated
+
+- **WAV renders, cache off vs on**, across all three affected algorithms. Every pair
+  diverged by ~100–170 LSB RMS (−46 to −50 dBFS), identical through the silent
+  count-in then diverging at the first audible sample. Crucially, **off-vs-off across
+  the three shipping legacy algorithms diverges by the same magnitude** — so
+  bit-exactness across orderings was never an engine invariant, and the cache's
+  divergence sits inside the existing inter-algorithm envelope. Verdict: correct to
+  the precision the engine itself permits.
+- **Direct stopwatch instrumentation.** Because the song is not bit-reproducible and
+  is CPU-saturated, black-box A/B on aggregate timing was inconclusive (different
+  windows, GC, saturation). A `Stopwatch` around the collection phase
+  (`SchedulingOverheadUs`, EMA) and around the per-wave barrier (`BarrierWaitUs`)
+  measured the two slices directly and confound-free.
+- **Long-run stability.** Cache-on ran fault-free across the full test windows.
+  A startup crash observed once was a pre-existing construction-window teardown race
+  (NRE past the `Ready && host != null` guard, i.e. `DLL.Info`/host torn down on
+  another thread during init) — not introduced by the cache, gone once the graph
+  settled, and now covered by the worker-thread fault probe (see PR "not in this
+  PR").
+
+## 7. What the measurements showed (and corrected)
+
+Per-chunk decomposition on the audio thread (~3.9 ms budget, Threads algorithm):
+
+```
+OtherMs p50  ≈ 3.8 ms   (audio-thread wall per chunk)
+  ├─ collection  (SchedulingOverheadUs)  ~260 µs off  →  ~11 µs on   ← this PR
+  ├─ barrier     (BarrierWaitUs)         ~1.1 ms      (unchanged on/off)
+  └─ serial floor (remainder)            ~2.4 ms      (tick/sub-tick/event/mix/taps)
+```
+
+Findings:
+
+- The cache does exactly one thing and does it well: **~24–27× on the collection
+  slice** (≈260 µs → ≈11 µs; 290 → 10.6 on the first clean A/B). It leaves
+  everything else byte-for-byte identical, including the barrier — confirmed.
+- **The re-scan was not the dominant cost.** It is ~7% of the budget. The original
+  issue attributed a multi-millisecond floor to it via black-box toggling; the
+  direct stopwatch shows that was an over-attribution.
+- **The real floor is elsewhere and out of scope:** the per-wave barrier (~1.1 ms,
+  at ~2× parallel efficiency — the worker pool is under-fed) and a ~2.4 ms serial
+  audio-thread floor. Caveat: `BarrierWaitUs` includes DSP that runs during the
+  wait, and the serial-floor figure is sensitive to which musical section the EMA
+  samples, so treat ~2.4 ms as the long-run estimate (±a few hundred µs), not exact.
+- Consequently the cache **does not** move the dropout rate on a saturated song, and
+  was never going to. Its value is structural: O(N·D) → O(N) removes a
+  super-linearly-growing cost from the hot path, so the win scales with graph
+  complexity, and the layered order it produces is the prerequisite for batching
+  barriers later.
+
+## 8. Follow-ups (each its own change)
+
+- Make the cone a strict drop-in (§5) + test.
+- A deterministic test song for an absolute bit-exact gate (§6).
+- `WorkThreadEngine` robustness: catch/record/`finally`-`WorkDone` around
+  `TickAndWork` (also closes a hang-on-throw hole); independent of the cache.
+- The wave-boundary `workWaitHandle` Set/Reset race (rare pre-existing hang).
+- Phase-split probe for the ~2.4 ms serial floor (`TickPhaseUs` / `MixPhaseUs`),
+  ideally on a non-saturated song so the signal isn't buried — the real next lever.
+- Barrier batching over the cached layered order — the largest lever for saturated
+  songs.

--- a/docs/DESIGN_107_cached_work_order.md
+++ b/docs/DESIGN_107_cached_work_order.md
@@ -99,25 +99,24 @@ order** producing the **same output**. Four observations underwrite that:
    add/remove events and bump `TopologyGeneration`, forcing a rebuild on the next
    chunk.
 
-## 5. Known divergence (flagged for merge)
+## 5. Cone parity with the legacy walk
 
-The cone build **descends through control machines** (it pushes every source onto
-the traversal stack and only excludes controls from becoming work nodes). The legacy
-`CollectMachinesThatCanWork` stops recursing at any `workDone` machine, and controls
-are `workDone` from the prefix — so legacy never reaches an audio machine whose
-*only* path to Master is through a control. The cache therefore works a strict
-superset of legacy on graphs that route audio into a control.
+The cone walk **stops at control/editor machines** — when the walk reaches a control
+source it does not descend through it. This matches the legacy
+`CollectMachinesThatCanWork`, which stops recursing at any `workDone` machine, and
+controls are `workDone` from the prefix. So an audio machine whose *only* path to
+Master runs through a control is left unworked by both the cache and the legacy walk;
+the cache works exactly the legacy set, not a superset.
 
-Impact: for graphs where no audio feeds a control (the common case, and the test
-song), the cone is identical to the legacy set. Where audio *does* feed a control,
-the extra machines are wasted work, not wrong output — their only consumer (the
-control) already ran in the prefix with the previous buffer, exactly as in legacy.
-(A control that *forwards* audio to Master is already mis-ordered in the legacy
-prefix and is an unsupported topology either way.)
+This is well-formed, not just matched by luck: any audio machine `A` that feeds a
+cone machine `M` necessarily has its own audio path to Master (through `M`), so `A`
+is still reached by the descent. The only machines excluded are those reachable
+*solely* through a control — precisely the set legacy never worked. The Kahn pass is
+unaffected: in-degree counts only cone-internal sources, and a now-excluded machine
+cannot be an input to a cone machine, so every counted edge still resolves.
 
-Recommendation: for a strict drop-in, do not descend into controls (skip pushing a
-control source during the cone walk). One line, plus a test for the
-audio-feeds-control case.
+(An earlier prototype descended through controls, which worked a harmless superset on
+sane graphs. That was tightened to the strict-parity walk above before this PR.)
 
 ## 6. How it was validated
 
@@ -172,7 +171,6 @@ Findings:
 
 ## 8. Follow-ups (each its own change)
 
-- Make the cone a strict drop-in (§5) + test.
 - A deterministic test song for an absolute bit-exact gate (§6).
 - `WorkThreadEngine` robustness: catch/record/`finally`-`WorkDone` around
   `TickAndWork` (also closes a hang-on-throw hole); independent of the cache.


### PR DESCRIPTION
## Summary

The threaded/group/single-thread dispatch paths rebuild the machine work set from
scratch on every drain iteration of every audio chunk, via the
`Collect{Editor,Control,}MachinesThatCanWork` passes. That is an O(N·D) graph
re-scan per chunk (N machines, D dependency layers) whose result only changes when
the graph topology changes.

This PR replaces that re-scan with a **cached topological work order** that is
rebuilt only when the topology changes (a connection or machine is added/removed)
and otherwise walked in O(N). It is **opt-in behind a new `UseCachedWorkOrder`
engine setting, default off**, and falls back to the legacy walk on any cycle.

Measured effect on the audio thread's per-chunk scheduling cost: **≈260 µs → ≈11 µs
(~24×)** on a 77-machine song. See "Measured impact" for the honest scope — this is
a scalability win on the scheduling slice, **not** a fix for a CPU-saturated song.

## What this PR changes

- **`ReBuzz/Audio/CachedWorkOrder.cs`** (new) — builds, per topology, three things:
  an editor prefix (hidden control machines), a control prefix (visible control
  machines), and the audio waves (Kahn layers over the master-reachable cone,
  excluding controls and Master). The cone walk **stops at control/editor machines**
  rather than descending through them, so the work set is exactly the legacy walk's
  (an audio machine reachable only through a control is left unworked, as today —
  see "Faithfulness"). Carries a `HasCycle` flag and the invalidation keys
  (`BuiltGeneration`, `BuiltMachineCount`).
- **`ReBuzz/Audio/WorkManager.cs`** — dispatch routing plus cached variants of the
  three re-scan-family handlers (threads / groups / single-thread). Algorithm 1
  ("Recursive Tasks", the default) is **untouched** — it never re-scanned.
- **`ReBuzz/Core/ReBuzzCore.cs`** — `TopologyGeneration` counter.
- **`ReBuzz/Core/MachineCore.cs`** — bump `TopologyGeneration` in `AddInput` /
  `RemoveInput`.
- **`ReBuzzGUI/BuzzGUI.Common/Settings/EngineSettings.cs`** — the
  `UseCachedWorkOrder` flag.

## What this PR deliberately does *not* change

- **Algorithm 1 (default).** Out of scope; it has no re-scan.
- **The per-wave thread barrier.** The cache does not touch the barrier structure
  (confirmed by measurement: barrier wait is identical cache on/off). Batching
  barriers is possible future work that the cached layered order *enables*, but it
  is not in this PR.
- **The serial audio-thread floor** (tick/sub-tick/event handling, mix, taps).
  Out of scope.

## Design

Full detail in `DESIGN_107_cached_work_order.md`. In brief:

- **Prefix is a fixed partition, not part of the sort.** Editors then controls run
  first, unconditionally, every wave — exactly as the two legacy pre-passes. The
  cache stores them as two arrays and re-tests `Ready` when walking them (a native
  crash can clear `Ready` mid-buffer).
- **Audio waves are Kahn layers** over the cone of machines reachable from Master
  via `AllInputs`, excluding control/editor machines and Master itself (Master is a
  pure sink — `master.Work` is never dispatched). In-degree counts only
  cone-internal edges; control inputs are pre-satisfied by the prefix.
- **Within-wave order is left dynamic** (sorted by `performanceLastCount` per chunk,
  as today). It is numerically neutral: a machine sums its inputs in
  connection-list order regardless of sibling dispatch order.
- **Invalidation** is keyed on `TopologyGeneration` (connection add/remove) and
  `MachinesList.Count` (machine add/remove). Rebuild happens under `AudioLock` at
  the top of the chunk, so a walk never races a topology mutation.

**Faithfulness — same machines, same order, same output.** The cone walk stops at
control/editor machines, matching the legacy `CollectMachinesThatCanWork`, which
stops recursing at any `workDone` machine (controls are `workDone` from the prefix).
So the cache works exactly the legacy set — an audio machine whose only path to
Master runs through a control is left unworked by both. Master is excluded as a pure
sink (`master.Work` is never dispatched). Within-wave order is left dynamic and is
numerically neutral (a machine sums its inputs in connection-list order regardless of
sibling dispatch order).

## Correctness

The four questions that decide whether a cached order is safe (detailed in the
design note):

1. **Cycles** — the engine assumes a DAG and has no runtime cycle handling;
   `CollectMachinesThatCanWork` would stack-overflow on one. Acyclicity is enforced
   upstream by `SongCore.CanConnectMachines`. The Kahn build detects any cycle
   *deterministically* (`placed != cone.Count`) and the caller falls back to the
   legacy walk — strictly safer than today.
2. **Mid-chunk eligibility** — `AudioLock` is held for the whole buffer; all
   topology/`Ready` mutations take it. Only `workDone` changes mid-chunk. Native
   crash paths clear `Ready`, which the prefix walk and the dispatch guard re-test.
3. **Editor/control pre-passes** — preserved as the fixed prefix partition, not
   folded into the topo-sort.
4. **Wireless / dynamic graphs** — `IsWireless` is display-only, not used in
   scheduling. Connect/disconnect route through `AudioLock`-guarded actions that
   bump `TopologyGeneration`, triggering a rebuild.

## Measured impact

Direct `Stopwatch` instrumentation on the audio thread (a 77-machine song, RME
ASIO 256, 48 kHz, ~3.9 ms chunk budget, WorkAlgorithm = Threads):

| Metric (per chunk)        | cache off | cache on | note |
|---------------------------|-----------|----------|------|
| Scheduling / collection   | ~260 µs   | ~11 µs   | this PR's target; ~24× (27× on first A/B) |
| Barrier wait              | ~1.1 ms   | ~1.0 ms  | unchanged — cache does not touch it |
| Engine Total (summed DSP) | 1.0–2.4 ms| 1.0–2.4 ms| varies by musical section, not by flag |

**Honest scope:** the re-scan was ~7% of the chunk budget, not the dominant cost.
The original issue's framing (re-scan ≈ the multi-millisecond floor) came from
black-box toggling; direct measurement corrects it. The dominant costs are the
per-wave barrier (~1.1 ms) and a serial audio-thread floor (~2.4 ms), both outside
this PR. On a song already ~50% over budget at this buffer, removing ~250 µs does
not change the dropout rate — and is not expected to. **The value here is
structural:** the cost removed is O(N·D), so it grows super-linearly with graph
size; the win widens on larger/deeper graphs and sets up later barrier work.

## Risk & rollout

- Opt-in, default off. No behavior change unless the flag is set.
- Cycle → automatic fallback to the legacy walk.
- Stable across long runs in testing (cache-on ran fault-free for the full test
  windows; see "Open items" for the one startup caveat, which is pre-existing and
  not introduced here).

## Open items before merge

1. **No absolute bit-exact gate.** The test song is not bit-reproducible
   (free-running synth state diverges at the first audible sample, and the three
   *shipping* legacy algorithms already diverge from each other by the same
   magnitude — so bit-exactness across orderings was never an engine invariant).
   Validation showed cache divergence sits inside that existing inter-algorithm
   envelope. A deterministic test song (sample players + gain/sum tree, no free
   synths) would give an absolute gate; recommended as a follow-up test asset.
2. **Decide on the instrumentation.** `SchedulingOverheadUs` / `BarrierWaitUs` were
   added during this work to measure it. They are not part of this PR (kept on a
   separate branch) and can be brought in later as documented diagnostics if wanted.

## Not in this PR (recommended as separate work)

- **`WorkThreadEngine` robustness fix** — wrap `TickAndWork` so a single machine's
  exception is recorded (named) rather than killing the audio engine, and call
  `WorkDone()` in `finally` so the job counter can't leak on throw. This also closes
  a hang-on-throw hole. It helps the legacy path too and should land on its own
  merits, independent of this PR.
- **Wave-boundary barrier race** — `GetWorkItem()`'s `workWaitHandle.Reset()` can
  land after the next wave's `AllJobsAdded()` `Set()`, a rare pre-existing hang
  window in the shared engine. Worth its own issue.
- **Barrier batching** — the larger lever for saturated songs; enabled by this PR's
  layered order but a separate project.

## Test plan

- [ ] Build (38 projects), deploy all managed DLLs.
- [ ] Flag off: behavior unchanged (regression check on alg 0/2/single-thread).
- [ ] Flag on: long run, no faults, audio correct by ear.
- [ ] A/B `SchedulingOverheadUs` off vs on (expect ~260 → ~11 µs).
- [ ] Confirm rebuild fires on connect/disconnect and machine add/remove
      (`TopologyGeneration` / count change).
- [ ] Cycle path: confirm fallback (once `CanConnectMachines` is bypassed in a test
      harness, or via a unit test on `Rebuild`).
- [ ] Audio-feeds-control topology: confirm the cache works the same set as legacy
      (cone stops at controls).
