### PR TITLE
Contain machine `Work()` faults on the worker threads (don't kill the engine; don't leak the job counter)

### DIFF
--- a/ReBuzz/Audio/WorkThreadEngine.cs
+++ b/ReBuzz/Audio/WorkThreadEngine.cs
@@ -52,9 +52,27 @@ namespace ReBuzz.Audio
                                 var machine = wi.Machine;
                                 var buzz = Global.Buzz as ReBuzzCore;
 
-                                wi.TickAndWork(nSamples, true);
-
-                                WorkDone();
+                                try
+                                {
+                                    wi.TickAndWork(nSamples, true);
+                                }
+                                catch (System.Exception ex)
+                                {
+                                    // Contain a single machine's failure: an exception thrown
+                                    // from Work() must not tear down the whole audio engine
+                                    // (otherwise it surfaces as an unhandled exception on this
+                                    // worker thread and the process is killed). Record the
+                                    // culprit for diagnosis and carry on - the machine's output
+                                    // is stale for this chunk only.
+                                    RecordFault(machine?.Name, ex);
+                                }
+                                finally
+                                {
+                                    // Always balance the job counter, even on throw: a leaked
+                                    // counter would leave allDoneHandle unset and hang the
+                                    // per-wave barrier.
+                                    WorkDone();
+                                }
                             }
                             else
                             {
@@ -123,6 +141,20 @@ namespace ReBuzz.Audio
         private bool stopped;
         private int workCounter;
         private int nSamples;
+
+        // Diagnostics for contained Work() faults (see the worker loop above).
+        // Written only on the exceptional path, so there is no steady-state cost;
+        // inspect via a debugger or reflection when a fault is suspected.
+        internal static int WorkFaultCount;
+        internal static string LastFaultMachine = "(none)";
+        internal static string LastFaultMessage = "";
+
+        private static void RecordFault(string machineName, System.Exception ex)
+        {
+            Interlocked.Increment(ref WorkFaultCount);
+            LastFaultMachine = machineName ?? "(null)";
+            LastFaultMessage = ex.GetType().Name + ": " + ex.Message;
+        }
 
         public void Stop()
         {


### PR DESCRIPTION
## Summary

In the threaded dispatch path (`WorkThreadEngine`), each worker calls
`MachineWorkInstance.TickAndWork` directly with no exception boundary, and
`WorkDone()` is called only on the success path. Two consequences:

1. **An exception thrown from a machine's `Work()` is unhandled on the worker
   thread and tears down the whole process** (it surfaces as the unhandled-exception
   dialog, not a contained glitch).
2. **If a machine throws, `WorkDone()` is skipped**, so `workCounter` never
   decrements for that job — `allDoneHandle` is never set and the per-wave barrier
   (`AllDoneEvent().WaitOne()`) hangs.

This wraps the per-item work in `try/catch/finally`: a machine failure is contained
and recorded, and `WorkDone()` runs in `finally` so the counter is always balanced.

Single file, no public API change, independent of any other in-flight work.

## Change

`ReBuzz/Audio/WorkThreadEngine.cs`, worker loop:

```csharp
try
{
    wi.TickAndWork(nSamples, true);
}
catch (System.Exception ex)
{
    RecordFault(machine?.Name, ex);   // contain + record; output stale this chunk only
}
finally
{
    WorkDone();                       // always balance the counter, even on throw
}
```

Plus three `internal static` diagnostic fields (`WorkFaultCount`,
`LastFaultMachine`, `LastFaultMessage`) and a small `RecordFault` helper. They are
written only on the exceptional path — **no steady-state cost** — and are inspectable
via a debugger or reflection when a fault is suspected.

## Rationale / behaviour

- A single misbehaving machine should degrade to a one-chunk stale buffer (an audible
  glitch), not a dead application. This matches how the rest of the engine treats
  per-machine trouble (e.g. native crash paths clearing `Ready`).
- The `finally`-`WorkDone()` is the load-bearing part and is correct regardless of
  the catch policy: without it, a throw deadlocks the barrier.
- Recording (rather than silently swallowing) keeps faults visible for diagnosis.

## Design choice worth a maintainer's call

This **contains and continues**. If the project prefers **fail-fast**, the same
structure works by rethrowing after `RecordFault` — the `finally`-`WorkDone()` still
matters there so the engine doesn't hang *before* the exception propagates. I went
with contain-and-continue because the failure mode it replaces is a full-process
kill from one machine. Happy to switch to rethrow if preferred.

## Scope

- Threads (algorithm 2) path only — that's where `WorkThreadEngine` runs.
- No change to scheduling, ordering, or output for the non-faulting (normal) path.
- Diagnostic fields are `internal`, not public; no new public surface.

## Test plan

- [ ] Build; normal playback unaffected (no faults, identical behaviour).
- [ ] Inject a throwing machine (or a deliberately null-deref test machine): confirm
      the engine keeps running, audio continues, `WorkFaultCount` increments and
      `LastFaultMachine` names it.
- [ ] Confirm no hang after a throw (barrier still completes — `WorkDone` ran).

## Notes

Discovered while validating the cached work order (#107 / PR #108) — a startup-only
teardown race produced exactly this unhandled-NRE-on-a-worker signature. That race is
pre-existing and not in scope here; this PR hardens the worker loop so any such
fault, from any cause, is contained rather than fatal.
