### PR TITLE
Inline single-machine waves in the cached algorithm-2 dispatch

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -955,6 +955,20 @@ namespace ReBuzz.Audio
                     break;
 
                 int n = FillAndSortDescFrom(wave);
+
+                // A one-machine wave has no intra-wave parallelism to gain, so the
+                // AddWork/AllJobsAdded/WaitOne barrier round-trip is pure overhead.
+                // Run it inline on the dispatch thread instead (bit-neutral: same
+                // TickAndWork, same workDone). Mirrors HandleWorkAlgorithmGroupsCached.
+                if (n == 1)
+                {
+                    var machine = sortScratch[0];
+                    var workInstance = buzzCore.MachineManager.GetMachineWorkInstance(machine);
+                    workInstance.TickAndWork(workSamplesCount, true);
+                    machine.workDone = true;
+                    continue;
+                }
+
                 for (int s = 0; s < n; s++)
                 {
                     var machine = sortScratch[s];


### PR DESCRIPTION
# Inline single-machine waves in the cached algorithm-2 dispatch

Builds on #108. Follow-up discussed under #107.

## What

`HandleWorkAlgorithmGroupsCached` already runs a one-machine wave inline instead of dispatching it through the worker barrier. The algorithm-2 cached path (`HandleWorkAlgorithm2Cached`) does not — it sends every wave, including one-machine waves, through the full `AddWork` / `AllJobsAdded` / `AllDoneEvent().WaitOne()` round-trip.

This ports that same `n == 1` fast path into `HandleWorkAlgorithm2Cached`: when a wave has a single machine, run it inline on the dispatch thread and continue, skipping the barrier. Multi-machine waves are unchanged.

## Why

On any serial stretch of the graph, a one-machine layer has no intra-wave parallelism to gain, so paying a full multi-thread barrier round-trip (a kernel wake plus a kernel wait) to run it is pure synchronization overhead. With #108's cached layered order making the wave structure explicit, skipping the barrier for thin waves is a small, local change.

## Correctness

Inlining a one-machine wave changes which thread runs the machine, not the order it runs in or the arithmetic it does, so it is numerically neutral by construction. Verified by rendering deterministic chain songs (one source → N gain nodes in series → Master) to float32 offline before and after the change and comparing the audio sample-for-sample: bit-identical (the only file-level difference was the `PEAK` metadata chunk).

## Impact

Measured on deterministic depth-N chains (the worst case for barrier depth, since every layer is a single machine), played and settled. Per-chunk barrier time and the `OtherMs` p50 budget, baseline → inlined:

| N  | Barrier (µs) | OtherMs p50 (µs) |
|----|--------------|------------------|
| 8  | 124 → 33     | 235 → 100  (−57%) |
| 16 | 216 → 48     | 425 → 150  (−65%) |
| 24 | 439 → 61     | 730 → 220  (−67%) |
| 32 | 599 → 134    | 1020 → 340 (−67%) |

On a chain every audio wave is one machine, so all of them inline and the audio-wave barrier is skipped entirely; the residual barrier is the editor/control prefix dispatch, which this PR doesn't touch. Real graphs benefit in proportion to how much of their depth is single-machine layers.

## Scope

Small and self-contained — one method in `WorkManager.cs`, no new types, no config. The general case (multi-machine waves that still pay the per-wave barrier) is barrier batching over the cached layered order, which is being discussed under #107 as separate, larger work.

## Testing

- Bit-exact float32 render compare on the chain songs (above).
- Played the chains and a saturated multi-machine song with the change live; no faults (`WorkFaultCount` 0), no dropout regressions.
