### PR TITLE
Rebuild cached work order when empty while audio machines exist (fixe…

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -882,7 +882,14 @@ namespace ReBuzz.Audio
             var song = buzzCore.SongCore;
             long gen = buzzCore.TopologyGeneration;
             if (cachedOrder.BuiltGeneration != gen ||
-                cachedOrder.BuiltMachineCount != song.MachinesList.Count)
+                cachedOrder.BuiltMachineCount != song.MachinesList.Count ||
+                // Self-heal a stale EMPTY order: if the cache was built mid-load off a
+                // not-yet-wired graph (empty audio cone), it would otherwise stick until
+                // the machine count next changes. Rebuild while AudioWaves is empty but
+                // audio machines exist (count beyond prefix + Master), so it recovers on
+                // the next chunk once connections resolve.
+                (cachedOrder.AudioWaves.Length == 0 &&
+                 song.MachinesList.Count > cachedOrder.EditorPrefix.Length + cachedOrder.ControlPrefix.Length + 1))
             {
                 cachedOrder.Rebuild(song);
                 cachedOrder.BuiltGeneration = gen;


### PR DESCRIPTION
…s silent load on large graphs)# Rebuild the cached work order when it comes back empty while audio machines exist

Follow-up to #108 (cached work order). Fixes a silent-audio bug on large graphs.

## Symptom

On a large song (100+ machines) that takes a noticeable time to load, the graph loads but plays **silent** — no audio, no faults. Loading any additional machine (which changes the machine count) makes audio start. Stop/play and toggling `UseCachedWorkOrder` do not. Smaller/fast-loading songs never show it.

## Cause

The audio thread runs during song load (audio plays through open/new since the SkipAudio removal). On a slow-loading graph, a chunk can fire and call `GetOrBuildOrder` while the graph is only **partially wired** — machines present but connections not yet all made. `CachedWorkOrder.Rebuild` then walks Master's audio cone, finds it empty, and caches an **empty `AudioWaves`** with `BuiltGeneration`/`BuiltMachineCount` set to the current (already-final) values. The existing invalidation keys can't catch this: once load settles, neither the generation nor the machine count changes, so the empty order sticks and every wave is skipped → silence. Adding a machine bumps the count → rebuild → correct order → audio.

## Fix

Add one invalidation clause to `GetOrBuildOrder`: also rebuild when `AudioWaves` is empty **while audio machines exist** (machine count exceeds the editor prefix + control prefix + Master). A stale empty order can no longer stick — the next chunk after connections resolve rebuilds it, and audio recovers on its own.

```csharp
if (cachedOrder.BuiltGeneration != gen ||
    cachedOrder.BuiltMachineCount != song.MachinesList.Count ||
    (cachedOrder.AudioWaves.Length == 0 &&
     song.MachinesList.Count > cachedOrder.EditorPrefix.Length + cachedOrder.ControlPrefix.Length + 1))
```

It's O(1), and stops firing the moment `AudioWaves` is non-empty, so there's no per-chunk cost in the normal case.

## Notes / limits

- This is a **safety net, not the root cause.** The deeper fix is to not build/cache the order off a half-wired graph — e.g. bump `TopologyGeneration` on load-time connection wiring, or defer caching until load settles. The self-heal is cheap and robust regardless, and worth having even once the root cause is addressed.
- One benign edge case: a song with a **disconnected** generator (an audio machine that never reaches Master) keeps `AudioWaves` empty while the count exceeds the prefix, so it rebuilds every chunk — wasteful but not incorrect. Real songs (everything routes to Master) don't hit it.

## Testing

Reproduced on a ~130-machine graph that loaded silent and recovered only on machine-add; with this change it comes up with audio on load, no machine-add needed. Smaller graphs unaffected (the clause never fires once the cone is non-empty).
