### PR TITLE
Tick: clear only changed pvals, skip empty param-processing

### DIFF
--- a/ReBuzz/MachineManagement/MachineManager.cs
+++ b/ReBuzz/MachineManagement/MachineManager.cs
@@ -1344,7 +1344,13 @@ namespace ReBuzz.MachineManagement
                     foreach (var p in g.ParametersList)
                     {
                         if (p.Flags.HasFlag(ParameterFlags.State) && p.Type != ParameterType.Note)
+                        {
                             p.SetPValue(track, p.GetValue(track));
+                            // Record so Tick clears this pval. Tick now clears pvals per changed
+                            // parameter instead of sweeping all parameters, so a pval written
+                            // outside SetValue must be tracked here too.
+                            machine.parametersChanged[p] = track;
+                        }
                     }
                     track++;
                 }

--- a/ReBuzz/MachineManagement/MachineWorkInstance.cs
+++ b/ReBuzz/MachineManagement/MachineWorkInstance.cs
@@ -605,23 +605,33 @@ namespace ReBuzz.MachineManagement
                     audiom.AudioTick(Machine);
                 }
 
-                foreach (var paramTrack in Machine.parametersChanged)
+                // Skip the whole param-processing block when nothing changed this tick.
+                // In steady state parametersChanged is empty almost every tick, so this avoids
+                // the lock-taking ConcurrentDictionary.Clear() and the enumerator alloc. TickSent
+                // stays unconditional. Empty invoke/clear/Clear were no-ops, so this is bit-exact.
+                if (!Machine.parametersChanged.IsEmpty)
                 {
-                    var par = paramTrack.Key;
-                    var track = paramTrack.Value;
+                    foreach (var paramTrack in Machine.parametersChanged)
+                    {
+                        var par = paramTrack.Key;
+                        var track = paramTrack.Value;
 
-                    par.InvokeEvents(buzz, track);
+                        par.InvokeEvents(buzz, track);
+                    }
+
+                    // Clear pvals only for parameters that changed this tick (was: a full sweep
+                    // over every parameter). SetValue writes pvalues[track] and records the
+                    // parameter in parametersChanged together under machine.workLock, and
+                    // RefreshMachineParams (the only other pval writer) records into
+                    // parametersChanged too — so the changed set covers every dirty pval.
+                    // ClearPVal fills all tracks of the parameter; must run before Clear().
+                    foreach (var paramTrack in Machine.parametersChanged)
+                        paramTrack.Key.ClearPVal();
+
+                    Machine.parametersChanged.Clear();
                 }
 
-                Machine.parametersChanged.Clear();
                 TickSent = true;
-
-                // Set pvalues to NoValue immediately to avoid sending param value twice
-                for (int i = 0; i < Machine.ParameterGroupsList.Count; i++)
-                {
-                    for (int j = 0; j < Machine.ParameterGroupsList[i].ParametersList.Count; j++)
-                        Machine.ParameterGroupsList[i].ParametersList[j].ClearPVal();
-                }
             }
         }
 


### PR DESCRIPTION
# Tick: clear only changed pvals, and skip empty param-processing

Reduces the per-chunk cost of `CallTick`, which after the barrier work (lever A) had become co-equal with `BarrierWaitUs` as the largest per-chunk term. Tracks #107 (does **not** close it — the barrier and the remaining per-chunk cost stay open; this resolves the tick-floor sub-term).

## Problem

`MachineWorkInstance.Tick` cleared **every parameter of the machine** on every tick boundary via a full `ParameterGroupsList` sweep, regardless of whether any parameter changed:

```csharp
for (int i = 0; i < Machine.ParameterGroupsList.Count; i++)
    for (int j = 0; j < Machine.ParameterGroupsList[i].ParametersList.Count; j++)
        Machine.ParameterGroupsList[i].ParametersList[j].ClearPVal();
```

On a wide graph this is O(machines × parameters) per tick. Instrumentation on `det_grid_hv_08x04` (35 machines) measured the sweep at ~99.99% wasted: ~9.0M `ClearPVal` calls against ~600 parameters that actually changed (waste ratio ~9,000–16,000 : 1). Timing showed the sweep was ~39% of the per-machine tick body.

## Fix

Three parts, one bit-exact change (host engine only; no `.csproj` touched):

1. **Clear only what changed.** Replace the full sweep with a clear over `parametersChanged` (the set already maintained for event delivery). Safe because `ParameterCore.SetValue` writes `pvalues[track]` and records the parameter into `parametersChanged` together under `machine.workLock`, so the changed set covers every dirty pval. Runs before `parametersChanged.Clear()`.

2. **Skip empty param-processing.** Guard the invoke / clear / `Clear()` block with `if (!Machine.parametersChanged.IsEmpty)`. In steady state the dict is empty almost every tick, so this avoids the lock-taking `ConcurrentDictionary.Clear()` and the enumerator allocation. `TickSent = true` stays unconditional. Empty invoke / clear / `Clear()` were all no-ops, so behavior is unchanged.

3. **Track the one out-of-band pval writer.** `MachineManager.RefreshMachineParams` (native machines, `ForceParamRefreshOnTempoChange`) writes a pval via `SetPValue` without going through `SetValue`. It now records into `parametersChanged` too, so the changed-set clear still covers it.

## Measurement (`det_grid_hv_08x04`, 35 machines, RME @ AudioThreads=8)

`TickPhaseUs`, matched load (`BarrierWaitUs` ~347 µs baseline → 333 µs after, confirming the drop is the fix, not load drift):

| build | `TickPhaseUs` |
|---|---|
| baseline (full sweep) | ~319–369 µs |
| clear-only-changed | 226 µs |
| + `IsEmpty` guard | **168 µs** |

~51% reduction; the tick phase moves from co-equal with the barrier to roughly half of it. Post-fix waste ratio: 16,199 → 1 (cleared == changed).

## Correctness

Bit-exact offline HDR render gate on `det_grid_hv_08x04`, dev build vs release baseline: all 731,392 float32 samples identical (`data` payloads share an MD5; the only file-level difference is the `PEAK` chunk's render timestamp). The `IsEmpty` guard path was first exercised by this render and produced sample-identical output.

## Notes

- Probe-free; instrumentation stayed on `perf/instrument`.
- Does not address the periodic ~36 ms spikes on this song — separate issue, unchanged.
- Leave #107 open as the tracker for the barrier and remaining per-chunk cost.
