### PR TITLE
perf: stop allocating in the per-chunk audio path (I/O facades + SongTime)

### DIFF
--- a/ReBuzz/Core/MachineConnectionCore.cs
+++ b/ReBuzz/Core/MachineConnectionCore.cs
@@ -122,6 +122,20 @@ namespace ReBuzz.Core
             }
         }
 
+        // Tap-gated variant: fetches the SongTime only when a tap is actually
+        // registered, so the common no-tap path allocates nothing (SongTime is a
+        // class, and it was previously constructed per output connection per
+        // chunk as the call-site argument - before the Tap null check inside
+        // DoTap could run). Each invocation that does fire still gets its own
+        // fresh SongTime instance, preserving the previous per-call semantics
+        // for tap consumers.
+        internal void DoTap(Sample[] sampleBuffer, int nSamples, bool stereo, ReBuzzCore buzz)
+        {
+            if (Tap == null)
+                return;
+            DoTap(sampleBuffer, nSamples, stereo, buzz.GetSongTime());
+        }
+
         internal void UpdateBuffer(Sample[] samples, int nSamples)
         {
             float ampStart = interpolatorAmp.Value / 0x4000;

--- a/ReBuzz/Core/MachineCore.cs
+++ b/ReBuzz/Core/MachineCore.cs
@@ -83,6 +83,18 @@ namespace ReBuzz.Core
 
         public List<IMachineConnection> AllOutputs { get => outputs; }
 
+        // Visibility filters matching the public Inputs/Outputs facades exactly
+        // (see the property bodies above). The facades build a fresh List +
+        // ReadOnlyCollection on every get, which is fine for the GUI but not for
+        // the per-chunk engine loops below; hot engine code iterates the raw
+        // lists through these predicates instead. Same elements, same order,
+        // same body - bit-exact with the facade-based loops they replace.
+        internal static bool IsVisibleInput(IMachineConnection input)
+            => input.Source.OutputChannelCount > 0 && !(input.Source as MachineCore).Hidden;
+
+        internal static bool IsVisibleOutput(IMachineConnection output)
+            => output.Destination.InputChannelCount > 0 && !(output.Destination as MachineCore).Hidden;
+
         readonly Dictionary<int, string> inputChannelNames = new Dictionary<int, string>();
         readonly Dictionary<int, string> outputChannelNames = new Dictionary<int, string>();
 
@@ -1252,8 +1264,10 @@ namespace ReBuzz.Core
         {
             Array.Clear(stereoSamples, 0, nSamples);
 
-            foreach (var input in Inputs)
+            foreach (var input in inputs)
             {
+                if (!IsVisibleInput(input))
+                    continue;
                 var inputCore = input as MachineConnectionCore;
 
                 for (int i = 0; i < nSamples; i++)
@@ -1269,8 +1283,10 @@ namespace ReBuzz.Core
 
         internal void UpdateOutputs(Sample[] samples, int nSamples, bool denormal = true)
         {
-            foreach (var output in Outputs)
+            foreach (var output in outputs)
             {
+                if (!IsVisibleOutput(output))
+                    continue;
                 var outputCore = output as MachineConnectionCore;
                 outputCore.UpdateBuffer(samples, nSamples);
             }
@@ -1304,8 +1320,10 @@ namespace ReBuzz.Core
                 }
             }
 
-            foreach (var input in Inputs)
+            foreach (var input in inputs)
             {
+                if (!IsVisibleInput(input))
+                    continue;
                 var inputCore = input as MachineConnectionCore;
 
                 //if (inputCore.Source.IsActive)
@@ -1331,8 +1349,10 @@ namespace ReBuzz.Core
 
         internal void UpdateOutputs(List<Sample[]> multiSamplesOut, int nSamples)
         {
-            foreach (var output in Outputs)
+            foreach (var output in outputs)
             {
+                if (!IsVisibleOutput(output))
+                    continue;
                 var outputCore = output as MachineConnectionCore;
                 if (outputCore.SourceChannel < multiSamplesOut.Count &&
                     multiSamplesOut[outputCore.SourceChannel] != null)
@@ -1350,10 +1370,13 @@ namespace ReBuzz.Core
 
             float maxSample = 0.0f;
 
-            var connections = Name == "Master" ? Inputs : Outputs;
+            bool useInputs = Name == "Master";
+            var connections = useInputs ? inputs : outputs;
 
             foreach (var output in connections)
             {
+                if (useInputs ? !IsVisibleInput(output) : !IsVisibleOutput(output))
+                    continue;
                 var outputCore = output as MachineConnectionCore;
                 Sample[] samples = outputCore.Buffer;
                 for (int i = 0; i < num; i++)
@@ -1414,8 +1437,10 @@ namespace ReBuzz.Core
         internal void UpdateIsActive()
         {
             bool active = false;
-            foreach (var input in Inputs)
+            foreach (var input in inputs)
             {
+                if (!IsVisibleInput(input))
+                    continue;
                 active |= input.Source.IsActive;
             }
 

--- a/ReBuzz/MachineManagement/MachineWorkInstance.cs
+++ b/ReBuzz/MachineManagement/MachineWorkInstance.cs
@@ -64,7 +64,7 @@ namespace ReBuzz.MachineManagement
                     foreach (var output in Machine.AllOutputs)
                     {
                         if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
-                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
+                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz);
                     }
                 }
                 else if (Machine.Ready && manageMachineHost != null)
@@ -191,7 +191,7 @@ namespace ReBuzz.MachineManagement
                 {
                     if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
                     var outputCore = output as MachineConnectionCore;
-                    outputCore.DoTap(outputCore.Buffer, nSamples, true, buzz.GetSongTime());
+                    outputCore.DoTap(outputCore.Buffer, nSamples, true, buzz);
                 }
             }
             else
@@ -227,7 +227,7 @@ namespace ReBuzz.MachineManagement
                 foreach (var output in Machine.AllOutputs)
                 {
                     if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
-                    (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
+                    (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz);
                 }
             }
 
@@ -285,7 +285,7 @@ namespace ReBuzz.MachineManagement
                     foreach (var output in Machine.AllOutputs)
                     {
                         if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
-                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
+                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz);
                     }
                 }
                 else
@@ -296,11 +296,11 @@ namespace ReBuzz.MachineManagement
                         var outputConn = output as MachineConnectionCore;
                         if (multiSamplesOut[outputConn.SourceChannel] != null)
                         {
-                            outputConn.DoTap(multiSamplesOut[outputConn.SourceChannel], nSamples, true, buzz.GetSongTime());
+                            outputConn.DoTap(multiSamplesOut[outputConn.SourceChannel], nSamples, true, buzz);
                         }
                         else
                         {
-                            outputConn.DoTap(silentBuffer, nSamples, true, buzz.GetSongTime());
+                            outputConn.DoTap(silentBuffer, nSamples, true, buzz);
                         }
                     }
                 }
@@ -327,7 +327,7 @@ namespace ReBuzz.MachineManagement
                     foreach (var output in Machine.AllOutputs)
                     {
                         if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
-                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
+                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz);
                     }
                 }
                 else
@@ -337,7 +337,7 @@ namespace ReBuzz.MachineManagement
                     foreach (var output in Machine.AllOutputs)
                     {
                         if (output.Destination.InputChannelCount == 0 || (output.Destination as MachineCore).Hidden) continue;
-                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz.GetSongTime());
+                        (output as MachineConnectionCore).DoTap(samples, nSamples, true, buzz);
                     }
                 }
             }


### PR DESCRIPTION
# perf: stop allocating in the per-chunk audio path (I/O facades + SongTime)

## What

Two related, bit-exact changes to the host engine's per-chunk path (findings A1 and A2 of
the 2026-07-05 optimisation sweep):

1. **Engine-internal loops stop reading the allocating `Inputs`/`Outputs` facades.**
   `MachineCore.Inputs` and `.Outputs` build a fresh `List<IMachineConnection>` (growing
   from capacity 0) plus a `ReadOnlyCollection` wrapper on **every access**. That is fine
   for the GUI, but six engine-internal methods read them inside the per-machine,
   per-chunk loops: `GetStereoSamples`, both `UpdateOutputs` overloads,
   `GetMultiIOSamples`, `GetActivity`, and `UpdateIsActive`. These now iterate the raw
   `inputs`/`outputs` lists directly, with the facades' visibility filter factored into
   two small internal predicates (`IsVisibleInput`/`IsVisibleOutput`) whose conditions are
   character-identical to the property bodies. The public facades are unchanged.

2. **`SongTime` is no longer constructed per output connection per chunk.**
   `SongTime` is a class; `MachineWorkInstance` evaluated `buzz.GetSongTime()` as the
   argument to `connection.DoTap(...)` at eight call sites, each inside a
   `foreach (Machine.AllOutputs)` loop — i.e. *before* `DoTap`'s `Tap != null` check could
   run, so every chunk allocated one `SongTime` per (machine × output), tap or no tap.
   `MachineConnectionCore` gains a tap-gated internal `DoTap(..., ReBuzzCore)` overload
   that fetches the `SongTime` only when a tap is actually registered; the eight call
   sites now pass `buzz` instead of `buzz.GetSongTime()`. When a tap does fire, it still
   receives its own fresh `SongTime` instance, preserving the previous per-call semantics.

## Why

On a 35-machine song at ~172–187 chunks/s, the facade accesses alone are on the order of
**40–50 k heap allocations per second (several MB/s of steady-state garbage) generated
inside worker DSP time**, with the per-output `SongTime` construction adding thousands
more per second on connection-dense songs. This PR removes both sources; combined, the
no-tap steady state of these paths becomes allocation-free. Expected observable effects:
slightly lower per-machine `ENGINE%`, reduced Gen-0 collection cadence, tighter `OtherMs`
tail.

**Expectation-setting:** this does **not** touch the characterized per-wave barrier
(`BarrierWaitUs`); that coordination cost is work-queue serialization + worker wake and is
tracked separately (#107). `BarrierWaitUs` is expected to stay flat under this change.

## Bit-exactness

- The facade replacement enumerates the same backing lists, in the same order, under the
  same filter conditions, with unchanged loop bodies — same elements, same arithmetic.
  (Both old and new code enumerate the live connection lists at the same program points,
  so concurrency behaviour is also unchanged.)
- The `DoTap` change only skips work that was already a no-op: when `Tap == null`, the old
  code allocated a `SongTime` and then did nothing with it. When `Tap != null`, behaviour
  is identical (fresh `SongTime` per invocation, same buffer copy, same delegate call).
- Offline HDR float32 render gate (byte-identical `data` payload, `PEAK` timestamp
  exempt): expected PASS; please run per the standard method before merge.

## Scope

- Host engine only: `ReBuzz/Core/MachineCore.cs`, `ReBuzz/Core/MachineConnectionCore.cs`,
  `ReBuzz/MachineManagement/MachineWorkInstance.cs`. No probes, no settings, no `.csproj`
  changes (machine or host), no public API changes.
- 3 files changed, 53 insertions(+), 14 deletions(-).

## Testing

- `git apply --check` verified against current trunk.
- Suggested measurement: PP2 default dumps (30 s+ settle, two per shape) on
  `det_grid_hv_08x04` and the Gain-Multi sweep before/after; watch `ENGINE%`,
  `TickPhaseUs`/`MixPhaseUs`, and the GC block. `BarrierWaitUs` flat is the expected (and
  correct) result.
