### PR TITLE
perf: remove allocating facades from the per-sub-chunk play path (WorkManager)

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -389,7 +389,7 @@ namespace ReBuzz.Audio
                         }
                     }
 
-                    foreach (var e in seq.Events)
+                    foreach (var e in seq.EventsList)
                     {
                         int eventTime = e.Key;
                         var seqEvent = e.Value;
@@ -492,9 +492,9 @@ namespace ReBuzz.Audio
             }
             else
             {
-                foreach (var seq in buzzCore.SongCore.Sequences)
+                foreach (var seq in buzzCore.SongCore.SequencesList)
                 {
-                    foreach (var se in seq.Events)
+                    foreach (var se in seq.EventsList)
                     {
                         var pattern = se.Value.Pattern as PatternCore;
                         PlayPatternColumnEvents(pattern, sampleCount);
@@ -1123,11 +1123,15 @@ namespace ReBuzz.Audio
 
         private void CollectControlMachinesThatCanWork()
         {
-            foreach (var mac in buzzCore.Song.Machines)
+            // Iterate the backing list directly instead of the Machines facade,
+            // which allocates via Where(...).Cast<IMachine>().ToReadOnlyCollection()
+            // on every access. The facade filters !Hidden && Ready; that predicate
+            // is inlined here (Ready was already re-tested below) so the visible
+            // set is identical to the previous facade-based loop.
+            foreach (var machine in (buzzCore.Song as SongCore).MachinesList)
             {
-                var machine = mac as MachineCore;
                 // Was work called for this control machine already?
-                if (machine.DLL.Info.Flags.HasFlag(MachineInfoFlags.CONTROL_MACHINE) && !machine.workDone && machine.Ready)
+                if (!machine.Hidden && machine.DLL.Info.Flags.HasFlag(MachineInfoFlags.CONTROL_MACHINE) && !machine.workDone && machine.Ready)
                 {
                     workSet.Add(machine);
                 }


### PR DESCRIPTION
# perf: remove allocating facades from the per-sub-chunk play path (WorkManager)

Follow-up to #114. Same theme — no allocating facade properties inside the per-chunk
audio path — applied to the pattern/sequence playback path in `WorkManager`. Findings A3
and A4 of the 2026-07-05 optimisation sweep. Single file, all bit-exact.

## What

Three facade accesses in `WorkManager.cs`, all read while playing, now go straight to the
backing collections:

1. **`SequenceCore.Events` → `EventsList`** (two sites: `UpdatePatternPositions`,
   `UpdatePatternColumnEvents`). `Events` builds a fresh
   `ReadOnlyDictionary<int, SequenceEvent>` wrapper on every get; both consumers only
   `foreach` it. `EventsList` is the same underlying `OrderedDictionary`, so enumeration
   order and element shape (`KeyValuePair<int, SequenceEvent>`) are identical — the wrapper
   just forwards to the same enumerator.

2. **`SongCore.Sequences` → `SequencesList`** (in `UpdatePatternColumnEvents`). `Sequences`
   runs `Cast<ISequence>().ToReadOnlyCollection()` per access; the loop only needs the
   `SequenceCore` items. `UpdatePatternPositions` already iterates `SequencesList` this way,
   so this makes the two paths consistent.

3. **`SongCore.Machines` → `MachinesList`** in `CollectControlMachinesThatCanWork`. The
   `Machines` facade is `machinesList.Where(m => !m.Hidden && m.Ready).Cast<IMachine>()
   .ToReadOnlyCollection()` — a filter + cast + materialisation on every access, run once
   per drain wave on the legacy (non-cached) and cycle-fallback scheduling paths. The
   loop now iterates `MachinesList` directly with the facade's `!Hidden && Ready`
   predicate inlined (`Ready` was already re-tested in the body; `!Hidden` is added so the
   visible set is unchanged). Mirrors the existing `CollectEditorMachinesThatCanWork`.

## Why

These run per sequence / per sub-chunk while playing (sites 1–2) and per drain wave on the
legacy scheduler (site 3), each allocating a wrapper or a full LINQ materialisation. This
removes that churn from the play path. Effect is GC-hygiene plus a small reduction in
per-sub-chunk work; as with #114, **`BarrierWaitUs` is unaffected** and expected to stay
flat.

Note on site 3: with `UseCachedWorkOrder` ON (the measured default) the control-collect
path is largely bypassed, so its practical benefit is on the legacy scheduling paths — the
change is included because it is mechanical and bit-exact, not because it moves the default
config's numbers.

## Bit-exactness

- All three are backing-collection swaps that enumerate the same elements in the same
  order under the same (or an inlined-identical) filter. `Events`/`Sequences` carry no
  predicate; `Machines`'s `!Hidden && Ready` is reproduced exactly.
- No behavioural or concurrency change: same objects enumerated at the same program
  points.
- Offline float32 render gate: expected PASS (please run before merge per standard
  method).

## Deliberately NOT in this PR

- **A5 (`PatternColumnCore.GetEvents` `ToArray()` elimination)** was pulled during
  implementation. `GetEvents` is also called by the BMX/BMXML **save** paths
  (`BMXFile.cs`, `BMXMLFile.cs`), not only the audio thread, so returning the reused
  `patternEventsList` would let a save-during-playback share and clobber that list with the
  engine. That makes it a concurrency question rather than a trivially-safe swap, so per the
  sweep's "riskier steps get their own PR" principle it moves to a dedicated follow-up
  (along with the `GetEvents` Clear-inside-lock tidy-up).

## Scope

- Host engine only: `ReBuzz/Audio/WorkManager.cs`. No probes, no settings, no `.csproj`
  changes (machine or host), no public API changes — the `Events`/`Sequences`/`Machines`
  facades themselves are untouched and remain for the GUI/API surface.
- 1 file changed, 12 insertions(+), 8 deletions(-).

## Testing

- `git apply --check` verified against current trunk (post-#113/#114); also verified against
  the raw pre-merge snapshot, since `WorkManager.cs` was touched by neither merge.
- Suggested measurement: PP2 default dumps on `det_grid_hv_08x04` and the Gain-Multi sweep;
  `TickPhaseUs`/`ENGINE%`/GC block before-after, `BarrierWaitUs` expected flat.
