### PR TITLE
perf: zero-latency fast path + branchless ring wrap in MachineConnectionCore.UpdateBuffer

### DIFF
--- a/ReBuzz/Core/MachineConnectionCore.cs
+++ b/ReBuzz/Core/MachineConnectionCore.cs
@@ -142,11 +142,36 @@ namespace ReBuzz.Core
             float ampCurrent = interpolatorAmp.Tick() / 0x4000;
             float ampStep = (ampStart - ampCurrent) / nSamples;
 
+            // Zero-latency fast path. When addedLatency == 0 the latency ring's
+            // read position always equals its write position (both start equal
+            // and advance in lockstep), so the ring is a pass-through: the second
+            // loop below would read back exactly what the first loop wrote. Write
+            // the amp/pan-scaled samples straight into buffer instead, skipping
+            // the ring copy and the per-sample modulo. Arithmetic, the amp ramp,
+            // and the interpolatorAmp.Tick() side effect above are all identical
+            // to the ring path, so this is bit-exact. latencyBuffer is read
+            // nowhere else, and every transition back to a latency > 0 state goes
+            // through UpdateLatencyBuffers, which resets both positions - so not
+            // advancing them here is unobservable.
+            if (addedLatency == 0)
+            {
+                for (int i = 0; i < nSamples; i++)
+                {
+                    buffer[i].L = samples[i].L * ampStart * panL;
+                    buffer[i].R = samples[i].R * ampStart * panR;
+                    ampStart += ampStep;
+                }
+                return;
+            }
+
+            // Latency-compensated path. Ring wrap via a branch rather than a
+            // per-sample integer divide (% Length); positions are always
+            // < Length, so ++pos == Length is exactly the wrap case.
             for (int i = 0; i < nSamples; i++)
             {
                 latencyBuffer[latencyBufferWritePos].L = samples[i].L * ampStart * panL;
                 latencyBuffer[latencyBufferWritePos].R = samples[i].R * ampStart * panR;
-                latencyBufferWritePos = (latencyBufferWritePos + 1) % latencyBuffer.Length;
+                if (++latencyBufferWritePos == latencyBuffer.Length) latencyBufferWritePos = 0;
                 ampStart += ampStep;
             }
 
@@ -154,7 +179,7 @@ namespace ReBuzz.Core
             {
                 buffer[i].L = latencyBuffer[latencyBufferReadPos].L;
                 buffer[i].R = latencyBuffer[latencyBufferReadPos].R;
-                latencyBufferReadPos = (latencyBufferReadPos + 1) % latencyBuffer.Length;
+                if (++latencyBufferReadPos == latencyBuffer.Length) latencyBufferReadPos = 0;
             }
         }
 


### PR DESCRIPTION
# perf: zero-latency fast path + branchless ring wrap in MachineConnectionCore.UpdateBuffer

Finding B1 of the 2026-07-05 optimisation sweep. `UpdateBuffer` runs once per connection
per sub-chunk; on connection-dense graphs (the `08x04` Gain-Multi mesh is ~100+
connections) its per-sample cost is the one Tier-B item with a plausibly measurable effect
on the DSP wall. Single file, bit-exact.

## What

Two changes to `MachineConnectionCore.UpdateBuffer`:

1. **Zero-latency fast path.** When `addedLatency == 0`, the latency ring is a
   pass-through — its read position always equals its write position (both start equal and
   advance in lockstep), so the existing second loop reads back exactly what the first loop
   wrote, i.e. the method is a double copy of `nSamples` samples through the ring for no
   effect. The fast path writes the amp/pan-scaled samples straight into `buffer` in a
   single loop and returns, skipping the ring copy and the second loop entirely.

2. **Branchless ring wrap on the latency path.** `latencyBuffer.Length` is
   `256 + addedLatency`, generally not a power of two, so `pos = (pos + 1) % Length`
   compiles to a real integer divide, executed twice per sample (write loop + read loop).
   Positions are always `< Length`, so `if (++pos == Length) pos = 0` is exactly
   equivalent and replaces the divide with a predictable branch.

## Why

The zero-latency case is the overwhelmingly common one (latency compensation is only added
for machines that report latency). For every such connection this removes a full
`nSamples`-sample `Sample` copy, the second loop, and `2 * nSamples` integer divides per
sub-chunk. The latency-compensated path keeps identical behaviour but drops its
per-sample divides too. As with the other sweep PRs, this is engine DSP-time work and does
**not** touch `BarrierWaitUs` — expected flat.

## Bit-exactness

- **Fast path arithmetic** is the same expression (`samples[i].L * ampStart * panL`, same
  `(x * ampStart) * panL` grouping) with the same `ampStart += ampStep` ramp as the ring
  path. In the zero-latency case the ring path already produces
  `buffer[i] = samples[i] * ampStart_i * pan`, independent of the (equal) read/write
  offset, so the direct write is identical.
- **interpolatorAmp.Tick()** — the interpolator advance is a side effect and stays above
  the branch, so it fires exactly once per call on both paths, unchanged.
- **Frozen positions are unobservable.** The fast path does not advance
  `latencyBufferReadPos`/`WritePos`. `latencyBuffer` is read nowhere else in the class, and
  the only way to (re-)enter a `latency > 0` state is `UpdateLatencyBuffers`, which
  unconditionally resets both positions (`readPos = 0`, `writePos = latencyDelta`) and
  resizes the ring. So no later code can observe a difference between "positions frozen at
  0" and "positions advanced in lockstep".
- **Conditional wrap** equals the modulo for all reachable positions (`pos < Length`
  invariant), so the latency path is unchanged bit-for-bit.
- Offline float32 render gate: expected PASS on both a zero-latency song and a song with a
  latency-reporting machine in the graph (please include the latter in the gate run, since
  it is the path most changed in structure even though it is bit-exact).

## Scope

- Host engine only: `ReBuzz/Core/MachineConnectionCore.cs` (one method). No probes, no
  settings, no `.csproj` changes (machine or host), no API changes.
- Independent of #116 (`WorkManager` facades) — different files, mergeable in any order.
- 1 file changed, ~27 insertions(+), 4 deletions(-).

## Testing

- `git apply --check` verified against current trunk (`MachineConnectionCore.cs` is at its
  post-#114 state; unaffected by #113/#116).
- Suggested measurement: PP2 default dumps on the Gain-Multi mesh shapes (most connections)
  plus `det_grid_hv_08x04`; watch `MixPhaseUs`/`ENGINE%`. If you have a latency-reporting
  machine to hand, run one dump with it in-graph to exercise the compensated path.
