### PR TITLE
fix: send due MIDI note-offs without skipping list elements (reverse-iterate playingEvents)

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -476,11 +476,14 @@ namespace ReBuzz.Audio
             {
                 if (playingEvents.Count > 0)
                 {
-                    foreach (var pes in playingEvents.ToArray())
+                    // Iterate in reverse so RemoveAt is safe during iteration (and O(1)
+                    // at the tail); avoids the ToArray() snapshot allocation.
+                    for (int i = playingEvents.Count - 1; i >= 0; i--)
                     {
+                        var pes = playingEvents[i];
                         var machine = pes.Machine;
                         buzzCore.MachineManager.SendMIDINote(machine, pes.Channel, pes.MidiNote, 0);
-                        playingEvents.Remove(pes);
+                        playingEvents.RemoveAt(i);
                     }
                 }
                 return;
@@ -502,8 +505,10 @@ namespace ReBuzz.Audio
                 }
             }
 
-            // Send not offs
-            for (int i = 0; i < playingEvents.Count; i++)
+            // Send note offs. Iterate in reverse: RemoveAt(i) in a forward loop
+            // shifts the next element into slot i and skips it this pass, delaying
+            // a due note-off by a chunk or more.
+            for (int i = playingEvents.Count - 1; i >= 0; i--)
             {
                 var pes = playingEvents[i];
                 var pe = pes.Pe;


### PR DESCRIPTION
# fix: send due MIDI note-offs without skipping list elements

## What

`WorkManager.UpdatePatternColumnEvents` prunes expired `playingEvents` entries with
`RemoveAt(i)` inside a **forward** `for` loop without compensating the index. Removing
element `i` shifts element `i+1` into slot `i`, which the loop then skips — so when two
or more note-offs are due in the same pass, only every other one is sent, and the
skipped ones wait at least one more audio chunk (~5.3 ms at 256 samples / 48 kHz).
With `k` simultaneously-due note-offs, the last one is delayed by roughly `k/2` passes.
This is audible-behaviour: staccato MIDI-column material gets staggered releases.

Fix: iterate the expiry loop in **reverse** (`for (int i = Count - 1; i >= 0; i--)`),
which examines every element exactly once regardless of removals.

While here, the transport-stop flush a few lines above used
`playingEvents.ToArray()` (a snapshot allocation per stop-pass) plus `Remove(pes)`
(an O(n) search per element) purely to permit removal during iteration. The same
reverse-loop idiom removes both: no snapshot, and `RemoveAt` from the tail is O(1).

## Behaviour / compatibility

- **This is a deliberate behaviour fix, not a bit-exact change.** Songs using MIDI
  pattern columns will render note-offs at their correct time where they were
  previously delayed.
- Songs with **no MIDI pattern columns are entirely unaffected**: `playingEvents` is
  only populated by `PatternColumnType.MIDI` note-on events (`PlayPatternColumnEvents`),
  so both loops are no-ops. Verified by an offline float32 render gate on a
  non-MIDI-column song: byte-identical `data` payload before/after this change.
- Within a single pass, due note-offs are now sent in reverse list order rather than
  (partial) forward order. The events are independent per note/channel; no ordering
  semantics exist between them.

## Testing done

**Render gate (regression) — PASS.** Offline float32 render of a signal-bearing song
with no MIDI columns (`det_grid_08x04`, 365,696 frames), built pre/post on the same
box: `data` payload byte-identical (2,925,568 bytes); the only differing byte in the
two files is the wav `PEAK` chunk timestamp. Confirms the change is render-neutral
wherever `playingEvents` is unused — i.e. all songs without MIDI pattern columns.

**Behavioural reproduction recipe** (defect is also visible on inspection): a pattern
with a MIDI column carrying a chord of 4+ simultaneous note-ons with identical
durations, aimed at a sustaining target. Pre-fix, the note-offs stagger across
successive audio chunks (clear on a MIDI monitor; audible as ragged releases).
Post-fix, all due note-offs are sent in the same pass. The transport-stop flush is
semantically unchanged (all held notes still release and the list drains); it just
no longer allocates a snapshot per stop-pass.

## Scope

One file, `ReBuzz/Audio/WorkManager.cs`, two loops, +9/−4. No `.csproj` changes,
no probe/instrumentation code, no public API change.
