### PR TITLE
fix: master VU meter reads wrong buffer region + under-scans stereo + compounds scale

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1647,7 +1647,7 @@ namespace ReBuzz.Core
         internal void MasterTapSamples(float[] resSamples, int offset, int count)
         {
             var s = GetSongTime();
-            meterData.UpdateMax(resSamples, true, s);
+            meterData.UpdateMax(resSamples, true, s, offset, count);
 
             if (MasterTap == null) return;
 

--- a/ReBuzzGUI/BuzzGUI.Common/VUMeter.cs
+++ b/ReBuzzGUI/BuzzGUI.Common/VUMeter.cs
@@ -11,15 +11,23 @@ namespace BuzzGUI.Common
         float maxSampleLeft;
         float maxSampleRight;
 
-        public void UpdateMax(float[] buf, bool stereo, SongTime s)
+        // buf is interleaved stereo [L,R,L,R,...] in both callers (DoTap builds
+        // nSamples*2; master resSamples likewise). offset/count delimit the live
+        // region in floats; count < 0 means "to end of buffer". The stereo flag
+        // selects separate L/R vs. collapse-to-left (mono display), NOT the buffer
+        // layout. Fields hold the RAW peak; scaling to amplitude happens once in
+        // GetLevels (applying scale here would compound across updates between reads).
+        public void UpdateMax(float[] buf, bool stereo, SongTime s, int offset = 0, int count = -1)
         {
-            int count = buf.Length;
+            if (count < 0)
+                count = buf.Length - offset;
+            int end = offset + count;
+            if (end > buf.Length)
+                end = buf.Length;
 
-            float scale = (1.0f / 32768.0f);
             if (stereo)
             {
-                count = count / 2;
-                for (int i = 0; i < count; i += 2)
+                for (int i = offset; i + 1 < end; i += 2)
                 {
                     maxSampleLeft = Math.Max(maxSampleLeft, Math.Abs(buf[i]));
                     maxSampleRight = Math.Max(maxSampleRight, Math.Abs(buf[i + 1]));
@@ -27,22 +35,21 @@ namespace BuzzGUI.Common
             }
             else
             {
-                for (int i = 0; i < count; i += 2)
+                for (int i = offset; i < end; i += 2)
                 {
                     maxSampleLeft = Math.Max(maxSampleLeft, Math.Abs(buf[i]));
                 }
                 maxSampleRight = maxSampleLeft;
             }
-
-            maxSampleLeft *= scale;
-            maxSampleRight *= scale;
         }
 
         public (double, double) GetLevels()
         {
-            var db = Math.Min(Math.Max(Decibel.FromAmplitude(maxSampleLeft), -VUMeterRange), 0.0);
+            const float scale = 1.0f / 32768.0f;
+
+            var db = Math.Min(Math.Max(Decibel.FromAmplitude(maxSampleLeft * scale), -VUMeterRange), 0.0);
             double left = (db + VUMeterRange) / VUMeterRange;
-            db = Math.Min(Math.Max(Decibel.FromAmplitude(maxSampleRight), -VUMeterRange), 0.0);
+            db = Math.Min(Math.Max(Decibel.FromAmplitude(maxSampleRight * scale), -VUMeterRange), 0.0);
             double right = (db + VUMeterRange) / VUMeterRange;
 
             maxSampleLeft = 0;


### PR DESCRIPTION
# fix: master VU meter reads wrong buffer region + under-scans stereo + compounds scale

## What

`VUMeter.UpdateMax` and its master call site had three independent defects that made
the master VU meter read low and scan the wrong data:

1. **Master meter ignored `offset`/`count`.** `ReBuzzCore.MasterTapSamples(resSamples,
   offset, count)` passed the *entire* `resSamples` array to `UpdateMax`, which scanned
   from index 0 over `resSamples.Length`. The live audio region is `[offset,
   offset+count)`, so the meter measured the wrong span and rescanned the whole backing
   buffer every sub-chunk. Fixed by plumbing `offset`/`count` through to `UpdateMax`.

2. **Stereo scan covered only a quarter of the frames.** The stereo branch did
   `count = count / 2` and then iterated `i += 2`, so it visited only the first
   `buf.Length / 4` frames. With interleaved `[L,R,L,R,…]` data an `i += 2` walk must
   run to the end of the region, not half. Removed the erroneous halving.

3. **Scale compounded across updates.** `maxSampleLeft/Right *= scale` mutated the
   persistent max *fields* on every `UpdateMax` call, but `GetLevels` only resets them
   when read. `UpdateMax` fires multiple times per `GetLevels`, so the level was scaled
   by `scale^N` for N updates between reads — reading far too low and cadence-dependent.
   Fixed by keeping the RAW peak in the fields and applying `1/32768` once, in
   `GetLevels`.

## Buffer layout (why the `else` branch is unchanged)

Both callers pass **interleaved stereo** `[L,R,L,R,…]`: `MachineConnectionCore.DoTap`
builds `float[nSamples*2]`, and the master path is stereo. The `stereo` flag selects
separate-L/R vs. collapse-to-left (mono *display*), not the buffer layout — so the
`else` branch's `i += 2` reading `buf[i]` (left channel) is correct and is left as-is.

## Signature

`UpdateMax(float[] buf, bool stereo, SongTime s, int offset = 0, int count = -1)` —
`count < 0` means "to end of buffer". The defaults keep the connection-tap caller
(`Connection.cs`) compiling unchanged; only the master call site passes `offset`/`count`.
The stereo loop is bounded `i + 1 < end` so `buf[i+1]` never over-reads on an
odd-length region.

## Scope / testing

Touches `ReBuzzGUI/BuzzGUI.Common/VUMeter.cs` and one call site in
`ReBuzz/Core/ReBuzzCore.cs` (+19/−12). **`BuzzGUI.Common.dll` must be redeployed**
alongside `ReBuzz.dll`. No `.csproj` change, no probe code. Verification is visual, not
render-affecting: master VU should now track the true signal level (previously it sat
low), and the per-connection meters are unchanged. Suggested check: play a song at a
known level and confirm the master meter reads consistently with a connection meter on
the master input, and that the reading is stable rather than drifting with sub-chunk
cadence.
