### PR TITLE
perf: zero-alloc event dispatch on the audio play path + fix GetEvents lock races

### DIFF
--- a/Machines/ModernPianoroll/MPEStructures/MPEParameter.cs
+++ b/Machines/ModernPianoroll/MPEStructures/MPEParameter.cs
@@ -242,6 +242,11 @@ namespace WDE.ModernPatternEditor.MPEStructures
             return null;
         }
 
+        public void GetEventsInto(int tbegin, int tend, List<PatternEvent> dest)
+        {
+            dest.Clear();
+        }
+
         public void SetBeatSubdivision(int beatindex, int subdiv)
         {
             mBeatSubdivision[beatindex] = subdiv;

--- a/Machines/ModernPianoroll/MPEStructures/ReBuzzPatternColumn.cs
+++ b/Machines/ModernPianoroll/MPEStructures/ReBuzzPatternColumn.cs
@@ -52,6 +52,14 @@ namespace WDE.ModernPatternEditor.MPEStructures
             return patternEvents.Where(pe => pe.Time >= tbegin && pe.Time < tend).ToArray();
         }
 
+        public void GetEventsInto(int tbegin, int tend, List<PatternEvent> dest)
+        {
+            dest.Clear();
+            foreach (var pe in patternEvents)
+                if (pe.Time >= tbegin && pe.Time < tend)
+                    dest.Add(pe);
+        }
+
         public void SetBeatSubdivision(int beatindex, int subdiv)
         {
             beatSubdivision[beatindex] = subdiv;

--- a/ModernPatternEditor/ModernPatternEditor.NET/MPEStructures/MPEParameter.cs
+++ b/ModernPatternEditor/ModernPatternEditor.NET/MPEStructures/MPEParameter.cs
@@ -243,6 +243,11 @@ namespace WDE.ModernPatternEditor.MPEStructures
             return null;
         }
 
+        public void GetEventsInto(int tbegin, int tend, List<PatternEvent> dest)
+        {
+            dest.Clear();
+        }
+
         public void SetBeatSubdivision(int beatindex, int subdiv)
         {
             mBeatSubdivision[beatindex] = subdiv;

--- a/ModernPatternEditor/ModernPatternEditor.NET/MPEStructures/ReBuzzPatternColumn.cs
+++ b/ModernPatternEditor/ModernPatternEditor.NET/MPEStructures/ReBuzzPatternColumn.cs
@@ -61,6 +61,14 @@ namespace WDE.ModernPatternEditor.MPEStructures
             return patternEvents.Where(pe => pe.Time >= tbegin && pe.Time < tend).ToArray();
         }
 
+        public void GetEventsInto(int tbegin, int tend, List<PatternEvent> dest)
+        {
+            dest.Clear();
+            foreach (var pe in patternEvents)
+                if (pe.Time >= tbegin && pe.Time < tend)
+                    dest.Add(pe);
+        }
+
         public void SetBeatSubdivision(int beatindex, int subdiv)
         {
             beatSubdivision[beatindex] = subdiv;

--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -59,6 +59,9 @@ namespace ReBuzz.Audio
         readonly bool SpeedAdjustLinear = false;
 
         float[] playWaveBuffer = new float[256 * 2];
+        // Audio-thread-owned reusable buffer for PlayPatternColumnEvents (zero-alloc
+        // GetEventsInto). Single audio thread, fully consumed each column iteration.
+        readonly List<PatternEvent> playColumnEvents = new List<PatternEvent>();
 
         public WorkManager(ReBuzzCore buzzCore, WorkThreadEngine workEngine, int algorithm, EngineSettings settings)
         {
@@ -538,8 +541,8 @@ namespace ReBuzz.Audio
                     if (column.Machine == null)
                         continue;
 
-                    var ces = column.GetEvents(pattern.PlayPosition, pattern.PlayPosition + nextPos);
-                    foreach (var pe in ces)
+                    column.GetEventsInto(pattern.PlayPosition, pattern.PlayPosition + nextPos, playColumnEvents);
+                    foreach (var pe in playColumnEvents)
                     {
                         if (column.Type == PatternColumnType.MIDI)
                         {

--- a/ReBuzz/Core/PatternColumnCore.cs
+++ b/ReBuzz/Core/PatternColumnCore.cs
@@ -50,27 +50,48 @@ namespace ReBuzz.Core
                 metadata = new Dictionary<string, string>();
         }
 
-        List<PatternEvent> patternEventsList = new List<PatternEvent>(0);
         PatternEvent[] emptyPatternEventList = Array.Empty<PatternEvent>();
         Lock patternEventsLock = new Lock();
         // Returns the events from PatternColumn object. Not from pattern editor machine.
+        // Returns a fresh snapshot array (callers may enumerate it multiple times and
+        // across threads - e.g. the BMX save path Count()s then foreach()es it). All
+        // reads of the shared event list happen under the lock.
         public IEnumerable<PatternEvent> GetEvents(int tbegin, int tend)
         {
-            if (patternEvents.Count == 0)
-                return emptyPatternEventList;
-
-            patternEventsList.Clear();
             lock (patternEventsLock)
             {
+                if (patternEvents.Count == 0)
+                    return emptyPatternEventList;
+
+                var list = new List<PatternEvent>();
                 for (int i = 0; i < patternEvents.Count; i++)
                 {
                     var pe = patternEvents[i];
-
                     if (pe.Time >= tbegin && pe.Time < tend)
-                        patternEventsList.Add(pe);
+                        list.Add(pe);
+                }
+                return list.ToArray();
+            }
+        }
+
+        // Zero-alloc variant for the audio play path: fills a caller-owned buffer
+        // instead of allocating a snapshot array. `dest` MUST be owned exclusively by
+        // the caller (the audio thread passes its own reusable list); the old shared
+        // scratch field this replaces was itself a cross-thread race (its Clear() ran
+        // outside the lock). The lock guards the shared source list only.
+        public void GetEventsInto(int tbegin, int tend, List<PatternEvent> dest)
+        {
+            dest.Clear();
+            lock (patternEventsLock)
+            {
+                int count = patternEvents.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    var pe = patternEvents[i];
+                    if (pe.Time >= tbegin && pe.Time < tend)
+                        dest.Add(pe);
                 }
             }
-            return patternEventsList.ToArray();
         }
 
         public void SetBeatSubdivision(int beatindex, int subdiv)

--- a/ReBuzzGUI/BuzzGUI.Interfaces/IPatternColumn.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/IPatternColumn.cs
@@ -32,6 +32,7 @@ namespace BuzzGUI.Interfaces
         IDictionary<string, string> Metadata { get; }
 
         IEnumerable<PatternEvent> GetEvents(int tbegin, int tend);      // tbegin <= t < tend
+        void GetEventsInto(int tbegin, int tend, List<PatternEvent> dest);  // zero-alloc: fills a caller-owned buffer
         void SetEvents(IEnumerable<PatternEvent> e, bool set);
 
         void SetBeatSubdivision(int beatindex, int subdiv);


### PR DESCRIPTION
# perf: zero-alloc event dispatch on the audio play path + fix GetEvents lock races

## What

`PatternColumnCore.GetEvents(tbegin, tend)` is called once per playing column per
sub-chunk on the **audio thread** (`WorkManager.PlayPatternColumnEvents`), and every
call allocated a fresh `ToArray()` snapshot. It also had two thread-safety bugs.

This change splits the concern:

1. **`GetEvents` keeps its exact contract** — returns a fresh, independently
   enumerable snapshot array — because non-audio callers depend on that. In
   particular the BMX save path (`BMXFile.cs`) does `events.Count()` **then**
   `foreach (events)`, i.e. enumerates the result twice, and runs on the save thread
   which is **not** guarded by the audio lock (the save's `AudioLock` is commented
   out). Dozens of editor/action callers also `.ToArray()`/`.ToList()` it. All of them
   keep working unchanged.

2. **New `GetEventsInto(tbegin, tend, List<PatternEvent> dest)`** fills a
   **caller-owned** buffer instead of allocating. The audio thread passes its own
   reusable `List<PatternEvent>` (single audio thread; the buffer is fully consumed
   each column iteration). `WorkManager.PlayPatternColumnEvents` is converted to this
   — killing the per-sub-chunk/per-column allocation on the hot path.

3. **Fixes two pre-existing lock races in `GetEvents`.** The old code read
   `patternEvents.Count` and called `patternEventsList.Clear()` **outside**
   `patternEventsLock`, mutating a **shared instance scratch list** — so two threads
   calling `GetEvents` on the same column (e.g. audio play + a concurrent save) raced
   on that list. The shared scratch field is **removed entirely**; both `GetEvents`
   and `GetEventsInto` now do all shared-list reads under the lock, and
   `GetEventsInto` writes only into the caller's private buffer.

## Why this is safe (concurrency)

The hazard was the shared `patternEventsList` field reused across all callers. By
giving the one hot caller its own buffer and having every other caller get a private
snapshot array, no two threads ever touch the same result container. The lock scope is
unchanged in duration (it still only spans the read loop over the source list), so no
new contention on the audio thread.

## Behaviour

Event dispatch is **identical** — same events, same order, same times. Because the
dispatched MIDI/parameter events are unchanged, an offline float32 render of a song
that drives machines via pattern columns is **byte-identical** pre/post (suggested
gate: any `det_grid` song, PRE vs POST, `data` payload identical, only the wav `PEAK`
timestamp differs).

## Scope / deploy

`IPatternColumn.cs` (BuzzGUI.Interfaces) + `PatternColumnCore.cs` (ReBuzz) +
`WorkManager.cs` (ReBuzz), +34/−9. Adds one interface method. **Deploy
`BuzzGUI.Interfaces.dll` as well as `ReBuzz.dll`** — a stale interface dll would break
the new method binding. No `.csproj` change, no probe code.
