### PR TITLE
audio: expose a driver-reported dropout counter (`DriverResetCount`)

### DIFF
--- a/ReBuzz/Audio/AudioEngine.cs
+++ b/ReBuzz/Audio/AudioEngine.cs
@@ -126,6 +126,9 @@ namespace ReBuzz.Audio
 
         private void AsioOut_DriverResetRequest(object sender, EventArgs e)
         {
+            // True device-reported dropout (PP2 Option 2 v3): the ASIO driver
+            // could not be served in time and requested a reset.
+            ReBuzzCore.RecordDriverReset();
             // Seems to work better if we reset the audio device after call.
             dispatcher.BeginInvoke(() =>
             {
@@ -206,6 +209,9 @@ namespace ReBuzz.Audio
             {
                 if (e.Exception != null)
                 {
+                    // True device-reported dropout (PP2 Option 2 v3): WASAPI
+                    // stopped with an exception = the device faulted / underran.
+                    ReBuzzCore.RecordDriverReset();
                     // Seems to work better if we reset the audio device after call.
                     DispatcherTimer dt = new DispatcherTimer();
                     dt.Interval = TimeSpan.FromSeconds(1);

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1790,6 +1790,26 @@ namespace ReBuzz.Core
         // this (or the machine count) changes. Mutated under AudioLock.
         internal long TopologyGeneration;
 
+        // ─── Deadline-referenced audio dropout counter (PP2 Option 2, v3) ────
+        // The ONLY true, device-reported dropout signal observable in-process:
+        // the audio driver's own reset/xrun notification. ASIO raises
+        // AsioOut.DriverResetRequest; WASAPI raises PlaybackStopped with an
+        // exception. Both mean the device could not be served in time and forced
+        // a reset — an actual dropout. Coarse (one event can bundle several lost
+        // buffers, and it triggers a device rebuild) but REAL, unlike the
+        // budget-relative metrics or any wall-clock/ring inference from the
+        // managed side (which don't sit at the hardware deadline). Incremented
+        // by AudioEngine's driver-event handlers. Monotonic since process start;
+        // PP2 delta-samples. v1 (ring-empty) and v2 (Read wall-time) were both
+        // invalid — they instrumented CommonAudioProvider, which is not even the
+        // live path under ASIO (that's AudioWaveProvider).
+        internal static long DriverResets;
+        internal static void RecordDriverReset() =>
+            System.Threading.Interlocked.Increment(ref DriverResets);
+        public long DriverResetCount => DriverResets;
+        public void ResetAudioDropoutCounters() =>
+            System.Threading.Interlocked.Exchange(ref DriverResets, 0);
+
         public MachineCore CreateMaster()
         {
             var machine = MachineManager.GetMaster(this);


### PR DESCRIPTION
# audio: expose a driver-reported dropout counter (`DriverResetCount`)

## What

Adds a counter of **audio-driver reset/xrun events** and surfaces it on `ReBuzzCore` as
`DriverResetCount`. This is the count of times the output device could not be served in
time and forced a reset — i.e. an actual audio dropout, reported by the driver itself.

Two source events, both already handled in `AudioEngine`; this change only increments a
counter in each:

- **ASIO** — `AsioOut.DriverResetRequest` (`AsioOut_DriverResetRequest`).
- **WASAPI** — `WasapiOut.PlaybackStopped` with a non-null `Exception`.

## Why

The existing dropout indicators (in tooling built on ReBuzz) are *budget-relative* — they
compare per-buffer work time against a smoothed internal period. Under a small
internal-chunk / larger driver-buffer ratio, and with the audio fill thread on, those
inflate from callback-cadence and fill-thread sleep gaps rather than real underruns, so
they over-report on perfectly healthy playback. The driver's own reset notification is the
one signal that unambiguously means "the device dropped," so exposing it gives tools a
trustworthy dropout count to show alongside (or instead of) the heuristic one.

## Changes

- `ReBuzz/Core/ReBuzzCore.cs`
  - `internal static long DriverResets` + `internal static void RecordDriverReset()`
    (Interlocked).
  - `public long DriverResetCount => DriverResets;` — monotonic since process start;
    consumers delta-sample.
  - `public void ResetAudioDropoutCounters()`.
- `ReBuzz/Audio/AudioEngine.cs`
  - `ReBuzzCore.RecordDriverReset()` in `AsioOut_DriverResetRequest` and in the WASAPI
    `PlaybackStopped`-with-exception handler.

+26 lines, 2 files. No audio-path behaviour change — the driver-reset handling itself is
untouched; only a counter is incremented before the existing reset logic runs.

## Caveats

`DriverResetCount` is **coarse**: it counts driver *reset events* (each of which triggers a
device rebuild and may bundle several lost buffers), not individual late buffers. It is the
correct signal for real, serious dropouts, but it will not register a single marginally-late
buffer that the driver rode through. There is no finer-grained, device-accurate dropout
signal observable from managed code on this architecture (the fill thread and driver buffer
sit between the managed render path and the hardware deadline).

## Testing

- On healthy, continuously-playing songs (ASIO, fill thread on and off), `DriverResetCount`
  stays **0** while the older budget-relative metric reports several percent — confirming the
  new counter reflects real device behaviour rather than cadence artifacts.
- Under genuine overload that forces the driver to reset, it increments by one per reset, in
  step with the audible break and the momentary silence of the device rebuild.

## Scope / deploy

Host only → `ReBuzz.dll`. No `.csproj` change, no machine change, no new dependencies.
