### PR TITLE
perf: double-buffer MasterTapSamples to drop the per-sub-chunk allocation

### DIFF
--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -665,6 +665,22 @@ namespace ReBuzz.Core
         public event Action PatternEditorActivated;
         public event Action SequenceEditorActivated;
         public event Action<float[], bool, SongTime> MasterTap;
+
+        // ─── MasterTap double-buffer (avoid a per-sub-chunk alloc) ───────────
+        // The tap copy escapes to the GUI thread via BeginInvoke and is read
+        // there asynchronously, so a reused buffer must NOT be overwritten by
+        // the audio thread while the GUI is still reading it. Two buffers, each
+        // with an in-flight flag (0 = free, 1 = handed to GUI). The audio thread
+        // claims a free buffer via Interlocked.CompareExchange; the GUI callback
+        // clears the flag AFTER MasterTap.Invoke returns. If neither buffer is
+        // free (GUI fell behind) it allocates a fresh one for that sub-chunk —
+        // correctness is unconditional; the alloc-elision is best-effort.
+        // Buffers are audio-thread-owned for sizing; the flags are the only
+        // cross-thread state (Interlocked, so free/claim is atomic + ordered).
+        private float[] masterTapBufferA;
+        private float[] masterTapBufferB;
+        private int masterTapInFlightA;   // 0 free, 1 in flight
+        private int masterTapInFlightB;
         public event PropertyChangedEventHandler PropertyChanged;
 
         public event Action<string> ShowSettings;
@@ -1651,7 +1667,34 @@ namespace ReBuzz.Core
 
             if (MasterTap == null) return;
 
-            float[] samples = new float[count];
+            // Claim a free reuse buffer (correct size), else allocate. A buffer
+            // is claimable only if its in-flight flag flips 0 -> 1 atomically AND
+            // it is already the right length (count can change if the driver
+            // buffer size changes; a stale-size buffer is replaced).
+            float[] samples = null;
+            int claimed = 0;   // 0 = none (allocated), 1 = A, 2 = B
+            if (System.Threading.Interlocked.CompareExchange(ref masterTapInFlightA, 1, 0) == 0)
+            {
+                if (masterTapBufferA == null || masterTapBufferA.Length != count)
+                    masterTapBufferA = new float[count];
+                samples = masterTapBufferA;
+                claimed = 1;
+            }
+            else if (System.Threading.Interlocked.CompareExchange(ref masterTapInFlightB, 1, 0) == 0)
+            {
+                if (masterTapBufferB == null || masterTapBufferB.Length != count)
+                    masterTapBufferB = new float[count];
+                samples = masterTapBufferB;
+                claimed = 2;
+            }
+            else
+            {
+                // Both buffers still in flight (GUI behind) — fall back to a
+                // fresh allocation for this sub-chunk. Never overwrite a buffer
+                // the GUI may still be reading.
+                samples = new float[count];
+            }
+
             for (int i = 0; i < count; i++)
             {
                 samples[i] = resSamples[offset + i];
@@ -1659,9 +1702,21 @@ namespace ReBuzz.Core
 
             dispatcher.BeginInvoke(() =>
             {
-                if (MasterTap != null)
+                try
                 {
-                    MasterTap.Invoke(samples, true, s);
+                    if (MasterTap != null)
+                    {
+                        MasterTap.Invoke(samples, true, s);
+                    }
+                }
+                finally
+                {
+                    // Release the reuse buffer only after the GUI has finished
+                    // reading it. Allocated buffers (claimed == 0) just drop.
+                    if (claimed == 1)
+                        System.Threading.Interlocked.Exchange(ref masterTapInFlightA, 0);
+                    else if (claimed == 2)
+                        System.Threading.Interlocked.Exchange(ref masterTapInFlightB, 0);
                 }
             });
         }


### PR DESCRIPTION
# perf: double-buffer MasterTapSamples to drop the per-sub-chunk allocation

## What

`ReBuzzCore.MasterTapSamples` runs on the audio thread once per sub-chunk. When a
`MasterTap` handler is registered (scope, profiler, meters, etc.) it allocated a fresh
`float[count]` every call to hand a copy of the master output to the GUI thread via
`dispatcher.BeginInvoke`. This replaces that with a two-buffer reuse scheme, eliminating
the allocation in steady state.

## Why it needs care (the buffer escapes threads)

The copied buffer is passed to `BeginInvoke` and read asynchronously on the GUI thread
inside `MasterTap.Invoke`. A naively reused buffer could be overwritten by the audio
thread while the GUI is still reading it — a torn-read data race. So the reuse is guarded:

- Two buffers, each with an in-flight flag (`0` free / `1` handed to GUI).
- The audio thread claims a free buffer with `Interlocked.CompareExchange(flag, 1, 0)`.
  The GUI callback clears the flag with `Interlocked.Exchange(flag, 0)` **after**
  `MasterTap.Invoke` returns, in a `finally` (so a throwing handler can't strand a
  buffer as permanently in-flight).
- If **neither** buffer is free (the GUI fell behind), it falls back to allocating a
  fresh buffer for that sub-chunk — exactly today's behaviour.

So correctness is unconditional: the audio thread never writes a buffer the GUI may be
reading. Only the allocation-elision is best-effort — it kicks in whenever the GUI keeps
up (the normal case), and safely degrades to allocating under a GUI stall. Buffers are
also re-allocated if `count` changes (driver buffer-size change).

## Not changed

- The VU-meter update (`meterData.UpdateMax(..., offset, count)`) and the unconditional
  `GetSongTime()` are left as-is — the meter path legitimately needs the `SongTime` every
  sub-chunk, independent of whether a tap is registered.
- Tap data delivered to handlers is byte-for-byte identical to before; only the buffer's
  provenance (reused vs freshly allocated) changes.

## Scope

`ReBuzz/Core/ReBuzzCore.cs` only, +58/−3. Host change → `ReBuzz.dll`. No `.csproj`
change, no interface change, no machine impact.

## Testing

Behaviour-preserving for tap consumers (identical sample data). Suggested check: run with
a `MasterTap` consumer active (e.g. a scope/meter) and confirm the displayed output is
unchanged, and that no torn/garbled frames appear under UI load (resize, drag) — the
fallback-allocate path covers GUI stalls. Not audio-path-affecting (the tap is a
read-only copy downstream of the mix), so no render-gate change is expected.
