### PR TITLE
perf: vectorise the audio-output scale loop in `MainAudioFillBuffer`

### DIFF
--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -243,9 +244,20 @@ namespace ReBuzz.Audio
                 }
 
                 float audioOutMul = 1 / 32768.0f;
-                for (int i = 0; i < count; i++)
+                // Vectorised scale to audio output range. Each lane computes the identical
+                // single-precision (in[i] * audioOutMul); no reduction, no FMA => bit-exact
+                // vs the scalar loop, which the tail below runs verbatim for the remainder.
+                Vector<float> audioOutMulVec = new Vector<float>(audioOutMul);
+                int vw = Vector<float>.Count;
+                int vi = 0;
+                for (; vi <= count - vw; vi += vw)
                 {
-                    buffer[offset + i] = buffer[offset + i] * audioOutMul; // From Buzz to audio output scale
+                    Vector<float> v = new Vector<float>(buffer, offset + vi);
+                    (v * audioOutMulVec).CopyTo(buffer, offset + vi);
+                }
+                for (; vi < count; vi++)
+                {
+                    buffer[offset + vi] = buffer[offset + vi] * audioOutMul; // From Buzz to audio output scale
                 }
 
                 // Update sample counters


### PR DESCRIPTION
## perf: vectorise the audio-output scale loop in `MainAudioFillBuffer`

Scope: **one loop, host-only** (`ReBuzz/Audio/WorkManager.cs`). No machine
`.csproj`, no interface, no Gear touched. First of the B2 SIMD items, deliberately
minimal per "smallest possible scope per PR — least reviewable, so smallest diff."

### What changes

The per-callback final scale from Buzz range to audio-output range:

```
for (int i = 0; i < count; i++)
    buffer[offset + i] = buffer[offset + i] * audioOutMul;   // audioOutMul = 1/32768f
```

becomes a `Vector<float>` body over the aligned bulk plus a scalar tail that runs the
**original expression verbatim** for the remaining `count % Vector<float>.Count`
elements. Adds `using System.Numerics;` (in-box; no package dependency).

### Why it is bit-exact (by construction, not just measured)

- The operation is an element-wise multiply by a **compile-time constant**. Each SIMD
  lane computes the identical single-precision `buffer[offset+i] * audioOutMul` — the
  same IEEE-754 multiply as the scalar loop.
- There is **no horizontal reduction** (no cross-lane sum), so no reassociation is
  introduced; lane order is irrelevant to each element's result.
- It is a bare multiply, so **no FMA** contraction is possible.
- Result is therefore independent of `Vector<float>.Count` (8 on AVX2, 16 on AVX-512):
  the same per-element bit pattern on any width.
- The tail loop is the pristine scalar statement, so the `count % width` remainder is
  trivially identical.

### Verification

- `git apply --check --whitespace=error` clean against `cd77415`.
- Brace/paren balance preserved (paren delta +6/+6; braces +1 block).
- CRLF + UTF-8 BOM preserved (first hunk at line 9; no line-1 diff).
- **Render gate (standard §5, zero-latency path):** `det_grid_hv_08x04`, offline HDR
  **float32**, PRE (`cd77415`) vs POST. Expect `data` payload byte-identical; only the
  wav `PEAK` chunk timestamp may differ. Signal-bearing render (non-vacuous):
  **`data` payload byte-identical; whole-file diff = 1 byte (the PEAK timestamp).**

Not compiler-checked in-sandbox (Linux); host built and run by maintainer
(VS 2026, .NET 10, Release x64).
