### PR TITLE
perf: replace scalar `Sample[]` copy loops with `Array.Copy` in `ManagedMachineHost.Work`

### DIFF
--- a/ReBuzz/ManagedMachine/ManagedMachineHost.cs
+++ b/ReBuzz/ManagedMachine/ManagedMachineHost.cs
@@ -450,10 +450,7 @@ namespace ReBuzz.ManagedMachine
                 bool flag = GeneratorBlockWork(outputBuffer, n, mode);
                 if (flag && (mode & WorkModes.WM_WRITE) != 0)
                 {
-                    for (int i = 0; i < n; i++)
-                    {
-                        samples[i] = outputBuffer[i];
-                    }
+                    Array.Copy(outputBuffer, samples, n);
                 }
                 return flag;
             }
@@ -461,18 +458,12 @@ namespace ReBuzz.ManagedMachine
             {
                 if ((mode & WorkModes.WM_READ) != 0)
                 {
-                    for (int j = 0; j < n; j++)
-                    {
-                        inputBuffer[j] = samples[j];
-                    }
+                    Array.Copy(samples, inputBuffer, n);
                 }
                 bool flag2 = EffectBlockWork(outputBuffer, inputBuffer, n, mode);
                 if (flag2 && (mode & WorkModes.WM_WRITE) != 0)
                 {
-                    for (int k = 0; k < n; k++)
-                    {
-                        samples[k] = outputBuffer[k];
-                    }
+                    Array.Copy(outputBuffer, samples, n);
                 }
                 return flag2;
             }


### PR DESCRIPTION
## perf: replace scalar `Sample[]` copy loops with `Array.Copy` in `ManagedMachineHost.Work`

Scope: **host-only** (`ReBuzz/ManagedMachine/ManagedMachineHost.cs`, compiles into
`ReBuzz.dll`). No machine `.csproj`, no interface, no Gear. Second B2 item, again
minimal per "smallest scope per PR."

### What changes

The three per-sub-chunk element-wise `Sample[]` copies in `Work`:

```
for (int i = 0; i < n; i++) samples[i]     = outputBuffer[i];   // generator write-back
for (int j = 0; j < n; j++) inputBuffer[j] = samples[j];        // effect input read
for (int k = 0; k < n; k++) samples[k]     = outputBuffer[k];   // effect write-back
```

become `Array.Copy(outputBuffer, samples, n)` / `Array.Copy(samples, inputBuffer, n)`
/ `Array.Copy(outputBuffer, samples, n)`. `System` is already imported; no new using.

### Why it is bit-exact (by construction)

`Sample` is a value type; `dst[i] = src[i]` is a bitwise struct copy, and `Array.Copy`
performs the identical bitwise element copy over `[0, n)` (an optimized memmove
internally). Same source range, same destination range, same bytes — the arrays never
alias (`samples`, `inputBuffer`, `outputBuffer` are distinct), and `Array.Copy` is
memmove-safe regardless. No arithmetic is involved, so there is nothing to round.

### Deliberately NOT changed

The `Array.Clear(outputBuffer, 0, outputBuffer.Length)` full-buffer clear is **kept**.
Narrowing it to `n` was considered and rejected: `outputBuffer[n..Length)` is never read
(both write-backs copy only `[0, n)`), so clearing the full buffer is redundant work —
but it is a defensive guarantee that a managed machine reading past `n` sees zeros, and
the saving (a ≤2 KB clear, zero when `n == 256`) does not justify the behavioural risk.

### Verification

- `git apply --check --whitespace=error` clean against `cd77415`.
- Brace balance PRE 140/140 → POST 137/137 (−3 blocks); paren balance 342/342 unchanged.
- CRLF + UTF-8 BOM preserved (first hunk at line 450; no line-1 diff).
- **Render gate (standard §5):** `det_grid_08x04` (reverb-free, deterministic; its Gain
  Multi managed effects drive the effect input/output copy loops), offline HDR
  **float32**, PRE (`cd77415`) vs POST. Expect `data` byte-identical; PEAK timestamp only.
  _[fill in once rendered]_

Not compiler-checked in-sandbox (Linux); host built and run by maintainer
(VS 2026, .NET 10, Release x64).
