### PR TITLE
fix: HD recorder must copy MasterTap samples before async queue (fixes #122 reuse-buffer corruption)

### DIFF
--- a/ReBuzzGUI/BuzzGUI.MachineView/HDRecorder/HDRecorderWindow.xaml.cs
+++ b/ReBuzzGUI/BuzzGUI.MachineView/HDRecorder/HDRecorderWindow.xaml.cs
@@ -385,12 +385,12 @@ namespace BuzzGUI.MachineView.HDRecorder
                     return;
                 }
 
-                bufferQueue.Add(samples);
+                bufferQueue.Add((float[])samples.Clone()); // own a copy: MasterTap reuse buffer is recycled after this returns (#122)
                 progress.Value = songtime.CurrentTick + (songtime.SubTicksPerTick > 0 ? (double)songtime.CurrentSubTick / songtime.SubTicksPerTick : 0);
             }
             else if (state == States.Recording)
             {
-                bufferQueue.Add(samples);
+                bufferQueue.Add((float[])samples.Clone()); // own a copy: MasterTap reuse buffer is recycled after this returns (#122)
             }
 
         }


### PR DESCRIPTION
#122 replaced per-call MasterTapSamples allocation with a 2-buffer reuse pool, released when the synchronous MasterTap handler returns. The HD recorder's handler queues the buffer reference for an async saveTask to write, so at high throughput (cached work order + multithreading) the audio thread laps the writer, recycles the buffer, and overwrites a chunk still queued — producing intermittent full-scale corruption in rendered wavs. Fix: the async consumer copies before queueing. Verified: det_grid_08x04, algorithm 2 + UseCachedWorkOrder On + MT on, 16/16 fresh renders now byte-identical and clean (was 11/12 corrupted).