### PR TITLE
fix: SignalAnalysisVST must copy MasterTap samples before async queue; document MasterTap contract

### DIFF
--- a/ReBuzzGUI/BuzzGUI.Interfaces/IBuzz.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/IBuzz.cs
@@ -98,7 +98,12 @@ namespace BuzzGUI.Interfaces
         event Action<int> MIDIInput;
         event Action PatternEditorActivated;
 
-        event Action<float[], bool, SongTime> MasterTap;            // fired in the GUI thread
+        // Fired on the audio work path, NOT the GUI thread. The samples array
+        // may be a reused buffer that is recycled as soon as the handler
+        // returns: it is only valid for the duration of the synchronous
+        // callback. Handlers that retain it (queue it, hand it to another
+        // thread) must copy it first ((float[])samples.Clone()). See #122/#125.
+        event Action<float[], bool, SongTime> MasterTap;
 
         // Extensions
         void SetModifiedFlag();

--- a/ReBuzzGUI/BuzzGUI.MachineView/SignalAnalysis/SignalAnalysisVSTWindow.xaml.cs
+++ b/ReBuzzGUI/BuzzGUI.MachineView/SignalAnalysis/SignalAnalysisVSTWindow.xaml.cs
@@ -175,7 +175,7 @@ namespace BuzzGUI.MachineView.SignalAnalysis
             {
                 if (vstReady)
                 {
-                    taskList.Add(samples);
+                    taskList.Add((float[])samples.Clone()); // own a copy: MasterTap reuse buffer is recycled after this returns (#122/#125); redundant-but-harmless for per-connection taps, which pass a fresh array
                 }
             }
 


### PR DESCRIPTION
Follow-up to #125. Audit of all MasterTap subscribers found one remaining retain-without-copy: SignalAnalysisVSTWindow queues the raw samples reference into taskList for a background VST thread, so #122's reuse pool can recycle the buffer before it's consumed — same torn-samples mechanism #125 fixed in the HD recorder, here feeding the analyzer instead of a wav. Fix is the same one-line clone. Also corrects the IBuzz.MasterTap doc comment ("fired in the GUI thread" — it fires on the audio work path) and documents the actual contract: buffer valid only during the synchronous callback; retainers must copy. All other subscribers verified safe (SignalAnalysisWindow copies synchronously, AboutWindow computes synchronously, AudioBlock ignores the buffer, per-connection Tap passes a fresh array). Render gate: det_grid_08x04 byte-identical (change is off the render path); Master analysis smoke-tested under cached+MT.