### PR TITLE
Make the WorkThreadEngine start-gate dispatcher-owned

### DIFF
--- a/ReBuzz/Audio/WorkThreadEngine.cs
+++ b/ReBuzz/Audio/WorkThreadEngine.cs
@@ -8,14 +8,18 @@ namespace ReBuzz.Audio
 {
     internal class WorkThreadEngine
     {
-        private readonly ManualResetEvent workWaitHandle;
+        // Dispatcher-owned wave gate. Workers only READ generation; they never
+        // write the go-signal. (The previous design had workers reset the
+        // go-signal handle in GetWorkItem, giving it two writers and no owner.)
+        // The dispatcher advances generation in AllJobsAdded to open each wave.
+        private readonly object gate = new();
+        private long generation;
         private readonly ManualResetEvent allDoneHandle;
         readonly Thread[] threads;
         readonly List<MachineWorkInstance> workList = new List<MachineWorkInstance>();
 
         public WorkThreadEngine(int numThreads)
         {
-            workWaitHandle = new ManualResetEvent(false);
             allDoneHandle = new ManualResetEvent(false);
             threads = new Thread[numThreads];
         }
@@ -31,13 +35,24 @@ namespace ReBuzz.Audio
             {
                 Thread t = new Thread(() =>
                 {
+                    // Per-thread: last wave generation this worker has observed.
+                    long seen = 0;
                     while (true)
                     {
                         if (stopped)
                             break;
 
-                        // Wait for a job
-                        workWaitHandle.WaitOne();
+                        // Wait for the dispatcher to open the next wave. The gate is
+                        // dispatcher-owned: we only read generation and never write it,
+                        // so a lagging worker can no longer clobber the next wave's open.
+                        // The predicate re-check under the lock makes a missed Pulse - or
+                        // a fully-skipped wave (this worker lagged past one) - safe.
+                        lock (gate)
+                        {
+                            while (!stopped && generation == seen)
+                                Monitor.Wait(gate);
+                            seen = generation;
+                        }
 
                         while (true)
                         {
@@ -104,7 +119,14 @@ namespace ReBuzz.Audio
 
         internal void AllJobsAdded()
         {
-            workWaitHandle.Set();
+            // Open the wave: advance the generation and wake the workers. This is the
+            // ONLY writer of the go-signal, and it is the dispatcher. Workers observe
+            // the new generation under gate and start draining workList.
+            lock (gate)
+            {
+                generation++;
+                Monitor.PulseAll(gate);
+            }
         }
 
         private void WorkDone()
@@ -136,7 +158,9 @@ namespace ReBuzz.Audio
                 }
                 else
                 {
-                    workWaitHandle.Reset(); // Wait until there are work available;
+                    // Empty: just report "no work". Workers no longer reset the
+                    // go-signal here (that shared ownership was the hazard); they fall
+                    // out of the drain loop and re-block on the dispatcher-owned gate.
                     return null;
                 }
             }
@@ -166,7 +190,12 @@ namespace ReBuzz.Audio
             {
                 stopped = true;
             }
-            workWaitHandle.Set();
+            // Wake any workers parked on the gate so they observe stopped and exit.
+            lock (gate)
+            {
+                generation++;
+                Monitor.PulseAll(gate);
+            }
 
             for (int i = 0; i < threads.Length; i++)
             {


### PR DESCRIPTION
## What

Makes the `WorkThreadEngine` start-gate **dispatcher-owned**. The parallel work engine's
"go" signal (`workWaitHandle`) previously had two writers with no owner: the dispatcher
set it in `AllJobsAdded`, and the *worker* threads reset it in `GetWorkItem` when the work
list drained. This replaces it with a monotonic `generation` counter advanced only by the
dispatcher, plus a condition-variable gate the workers only ever *read*.

## Why

The shared-ownership go-signal is a latent lost-wakeup hazard. It currently self-heals only
because the reset sits inside `workLock`; any change to that lock scope would turn it into a
hang. It also woke **all N** worker threads on every wave open, including waves with far
fewer items than threads. Filed previously as an engine-robustness item; this is that fix.

## Change

- Remove `workWaitHandle`. Add `private readonly object gate` + `private long generation`.
- Worker outer wait: `lock (gate) { while (!stopped && generation == seen) Monitor.Wait(gate); seen = generation; }`, with a per-thread `seen`.
- `AllJobsAdded()` — the only go-signal writer, and it's the dispatcher: `lock (gate) { generation++; Monitor.PulseAll(gate); }`.
- `GetWorkItem()` empty branch: `return null` only — no signal reset.
- `Stop()` pulses the gate so parked workers observe `stopped`.
- **Unchanged:** the completion path (`workCounter` / `allDoneHandle`) and the public API
  (`AddWork` / `AllJobsAdded` / `AllDoneEvent`). WorkManager dispatch call sites are untouched.

A worker that lagged a full wave just reads `generation > seen`, takes the latest, and
rejoins the current wave — no lost work, no stranded items (a worker only parks on a
genuinely empty list; completion is tracked by `workCounter`, independent of the go-signal).
`gate` is a plain `object` (not the `Lock` type) because `Monitor.Wait/Pulse` require an
object monitor. `gate` and `workLock` are never nested, so no lock-ordering risk.

## Validation

- **Bit-neutral by construction:** the per-wave completion barrier is untouched, so
  "all of wave K done before any of wave K+1" is preserved; the change only affects when
  workers *wake*, not the happens-before between waves. Output is already independent of
  worker order (fixed reduction order), so scheduling changes can't alter samples.
- **Empirical:** on the threaded path (algorithm 2 "Threads", MT on, UseCachedWorkOrder On,
  AudioThreads=8, RME Fireface ASIO, Release x64), the offline `det_grid_08x04` render is
  **byte-identical across two fresh runs** and equal to the current `main` build's output
  (data-chunk md5, trim-aware).

**Render-gate honesty:** the byte-gate was also run Multithreading OFF, which does **not**
instantiate `WorkThreadEngine` — so that run only confirms the change has no cross-path
effect; it does not exercise the modified code. The threaded path is validated by the two
clean, deterministic MT-on renders above plus the construction argument, not by the MT-off
gate. (No functional behavior change to smoke-test beyond the render itself.)

## Scope

One file: `ReBuzz/Audio/WorkThreadEngine.cs` (+36 / −7). No API or call-site changes.
Foundation for the follow-on barrier restructure (dependency-driven single per-buffer
barrier); this PR is behavior-preserving and independently shippable.
