### PR TITLE
perf: dependency-driven dispatch - one barrier per buffer instead of one per DAG level

### DIFF
--- a/ReBuzz/Audio/CachedWorkOrder.cs
+++ b/ReBuzz/Audio/CachedWorkOrder.cs
@@ -38,6 +38,33 @@ namespace ReBuzz.Audio
         public MachineCore[] ControlPrefix = Array.Empty<MachineCore>();
         public MachineCore[][] AudioWaves = Array.Empty<MachineCore[]>();
 
+        // --- Dependency graph for the dependency-driven dispatch (#107) -----------
+        // The Kahn layering below already computes in-degrees and walks successors, then
+        // throws that structure away and keeps only the flattened levels. Keeping it lets
+        // the dispatcher start a machine the instant ITS OWN inputs are done, rather than
+        // when its whole level is done: one barrier per buffer instead of one per level.
+        //
+        // Dense cone indices 0..Cone.Length-1. Same membership and edge semantics as
+        // AudioWaves (Master excluded - a pure sink; controls/editors excluded - they are
+        // prefix-worked).
+        //
+        // Indeg counts one per in-cone input EDGE and Succ holds one entry per in-cone
+        // output EDGE, so parallel (multi-channel) connections between the same pair
+        // appear repeatedly in BOTH - exactly as the Kahn drain counts and decrements
+        // them. Any asymmetry would leave a successor's countdown permanently above zero
+        // and hang the buffer, so both are built from the same edge enumeration.
+        //
+        // Populated only when !HasCycle (the cyclic case falls back to the legacy walk).
+        public MachineCore[] Cone = Array.Empty<MachineCore>();
+        public int[] Indeg = Array.Empty<int>();
+        public int[][] Succ = Array.Empty<int[]>();
+        public int[] Seed = Array.Empty<int>();
+
+        // Set if the graph fails to reproduce AudioWaves (see SelfCheck). The dispatcher
+        // refuses the dependency-driven path when this is set and uses the wave path,
+        // which is unchanged.
+        public bool SelfCheckFailed;
+
         // Invalidation keys. BuiltGeneration tracks connection add/remove
         // (ReBuzzCore.TopologyGeneration); BuiltMachineCount catches machine
         // add/remove without hunting every MachinesList.Add site.
@@ -78,6 +105,10 @@ namespace ReBuzz.Audio
             if (machines.Count == 0)
             {
                 AudioWaves = Array.Empty<MachineCore[]>();
+                Cone = Array.Empty<MachineCore>();
+                Indeg = Array.Empty<int>();
+                Succ = Array.Empty<int[]>();
+                Seed = Array.Empty<int>();
                 return;
             }
 
@@ -129,6 +160,10 @@ namespace ReBuzz.Audio
                 indeg[m] = d;
             }
 
+            // Snapshot the initial in-degrees: the Kahn drain below decrements indeg to
+            // zero as it places each layer, destroying them.
+            var indeg0 = new Dictionary<MachineCore, int>(indeg);
+
             var waves = new List<MachineCore[]>();
             var frontier = new List<MachineCore>();
             foreach (var kv in indeg)
@@ -164,6 +199,138 @@ namespace ReBuzz.Audio
                 HasCycle = true;
 
             AudioWaves = waves.ToArray();
+
+            // --- 3. Dependency graph -------------------------------------------
+            // Same cone, same edges, same multiplicity as the layering above - kept as a
+            // graph instead of flattened. Skipped on a cycle (the caller falls back to the
+            // legacy recursive walk; a cyclic graph could never drain anyway).
+            SelfCheckFailed = false;
+            if (HasCycle)
+            {
+                Cone = Array.Empty<MachineCore>();
+                Indeg = Array.Empty<int>();
+                Succ = Array.Empty<int[]>();
+                Seed = Array.Empty<int>();
+                return;
+            }
+
+            // Index order is arbitrary (HashSet enumeration) and does NOT affect output: a
+            // machine sums its inputs in connection-list order, independent of the order
+            // its siblings were dispatched in.
+            var coneArr = new MachineCore[cone.Count];
+            var coneIndex = new Dictionary<MachineCore, int>(cone.Count);
+            int ci = 0;
+            foreach (var cmm in cone)
+            {
+                coneArr[ci] = cmm;
+                coneIndex[cmm] = ci;
+                ci++;
+            }
+
+            var indegArr = new int[coneArr.Length];
+            var succArr = new int[coneArr.Length][];
+            var succTmp = new List<int>();
+            for (int ii = 0; ii < coneArr.Length; ii++)
+            {
+                var cm = coneArr[ii];
+                indegArr[ii] = indeg0[cm];
+
+                // One entry per EDGE (not per distinct destination), mirroring the drain's
+                // `foreach (output in m.AllOutputs) --indeg[dst]`.
+                succTmp.Clear();
+                foreach (var cout in cm.AllOutputs)
+                {
+                    if (!(cout.Destination is MachineCore cdst))
+                        continue;
+                    if (!cone.Contains(cdst))
+                        continue;
+                    succTmp.Add(coneIndex[cdst]);
+                }
+                succArr[ii] = succTmp.ToArray();
+            }
+
+            var seedList = new List<int>();
+            for (int si = 0; si < indegArr.Length; si++)
+            {
+                if (indegArr[si] == 0)
+                    seedList.Add(si);
+            }
+
+            Cone = coneArr;
+            Indeg = indegArr;
+            Succ = succArr;
+            Seed = seedList.ToArray();
+
+            SelfCheck();
+        }
+
+        // Validate the graph against the structure we already trust. Runs once per
+        // TOPOLOGY rebuild - never per buffer - so the cost is irrelevant.
+        //
+        // Drains Indeg/Succ/Seed with the same rule the dispatcher uses and requires the
+        // result to match AudioWaves exactly: same machines, same layer assignment.
+        // AudioWaves already drives the shipping cached dispatch, so it is a sound oracle.
+        //
+        // The failure this guards against is nasty: a wrong Succ (e.g. deduplicating
+        // parallel edges) leaves a successor's countdown permanently above zero, and the
+        // audio thread stalls mid-render. Catching it here turns a silent hang into a
+        // flag, and the dispatcher then simply uses the wave path.
+        private void SelfCheck()
+        {
+            var remaining = (int[])Indeg.Clone();
+            var layerOf = new int[Cone.Length];
+            for (int k = 0; k < layerOf.Length; k++)
+                layerOf[k] = -1;
+
+            var cur = new List<int>(Seed);
+            int layer = 0;
+            int drained = 0;
+            while (cur.Count > 0)
+            {
+                var nxt = new List<int>();
+                foreach (int idx in cur)
+                {
+                    layerOf[idx] = layer;
+                    drained++;
+                    foreach (int s in Succ[idx])
+                    {
+                        if (--remaining[s] == 0)
+                            nxt.Add(s);
+                    }
+                }
+                cur = nxt;
+                layer++;
+            }
+
+            // Everything must drain: a stuck countdown is exactly the hang we fear.
+            if (drained != Cone.Length || layer != AudioWaves.Length)
+            {
+                SelfCheckFailed = true;
+                return;
+            }
+
+            // Every machine must land in the layer AudioWaves put it in.
+            var waveLayer = new Dictionary<MachineCore, int>(Cone.Length);
+            for (int w = 0; w < AudioWaves.Length; w++)
+            {
+                foreach (var wm in AudioWaves[w])
+                    waveLayer[wm] = w;
+            }
+
+            if (waveLayer.Count != Cone.Length)
+            {
+                SelfCheckFailed = true;
+                return;
+            }
+
+            for (int k = 0; k < Cone.Length; k++)
+            {
+                if (!waveLayer.TryGetValue(Cone[k], out int wl) || wl != layerOf[k])
+                {
+                    SelfCheckFailed = true;
+                    return;
+                }
+            }
         }
     }
 }

--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -643,7 +643,9 @@ namespace ReBuzz.Audio
             }
             else if (algorithm == 2)
             {
-                if (engineSettings.UseCachedWorkOrder)
+                if (engineSettings.UseCachedWorkOrder && b2Enabled)
+                    HandleWorkAlgorithm2Dependency(master, workSamplesCount);
+                else if (engineSettings.UseCachedWorkOrder)
                     HandleWorkAlgorithm2Cached(master, workSamplesCount);
                 else
                     HandleWorkAlgorithm2(master, workSamplesCount);
@@ -973,6 +975,95 @@ namespace ReBuzz.Audio
                 HandleWorkList(numRead); // dispatches workSet, sets workDone, clears workSet
             else
                 workSet.Clear();
+        }
+
+        // ==== Dependency-driven dispatch (#107) ==================================
+        // Replaces the per-DAG-level barrier loop with ONE barrier per buffer. A machine
+        // starts the instant its own inputs are done rather than when its whole level is,
+        // so workers stay fed across what used to be wave boundaries.
+        //
+        // Used only when the cached order is valid AND its self-check passed; anything
+        // unexpected falls back to the wave path, which is unchanged.
+        private bool b2Installed;
+        private long b2InstalledGeneration = long.MinValue;
+        private int b2InstalledCount = -1;
+        private bool b2Enabled = true;
+
+        // The dispatcher's wait is bounded. A correct buffer completes in well under a
+        // millisecond, so 2s is absurdly generous - the point is that a completion bug
+        // degrades into a fallback plus a recorded diagnostic rather than freezing the
+        // audio thread. (The completion invariant is enforced by construction in
+        // WorkThreadEngine and the graph is validated by CachedWorkOrder.SelfCheck, so
+        // this should be unreachable; it is cheap insurance, not a substitute.)
+        private const int B2_WAIT_MS = 2000;
+        internal static int B2StallCount;
+        internal static string B2LastStall = "(none)";
+
+        // Build the engine-side graph once per topology, not per buffer.
+        private bool B2EnsureGraph(CachedWorkOrder order)
+        {
+            if (order.HasCycle || order.SelfCheckFailed || order.Cone.Length == 0)
+                return false;
+
+            if (b2Installed
+                && b2InstalledGeneration == order.BuiltGeneration
+                && b2InstalledCount == order.BuiltMachineCount)
+                return true;
+
+            var items = new MachineWorkInstance[order.Cone.Length];
+            for (int i = 0; i < order.Cone.Length; i++)
+                items[i] = buzzCore.MachineManager.GetMachineWorkInstance(order.Cone[i]);
+
+            workEngine.B2SetGraph(items, order.Indeg, order.Succ);
+            b2Installed = true;
+            b2InstalledGeneration = order.BuiltGeneration;
+            b2InstalledCount = order.BuiltMachineCount;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private void HandleWorkAlgorithm2Dependency(MachineCore master, int workSamplesCount)
+        {
+            var order = GetOrBuildOrder();
+            if (!B2EnsureGraph(order))
+            {
+                HandleWorkAlgorithm2Cached(master, workSamplesCount);
+                return;
+            }
+
+            workEngine.PrepareEngine(workSamplesCount);
+
+            // Prefix unchanged: editors, then controls, before the audio cone.
+            DispatchPrefixCached(order.EditorPrefix, workSamplesCount);
+            DispatchPrefixCached(order.ControlPrefix, workSamplesCount);
+
+            // The wave path marks workDone as it dispatches and other code reads it, so we
+            // mark the same set. Every cone machine runs this buffer, so marking up front
+            // is equivalent.
+            var cone = order.Cone;
+            for (int i = 0; i < cone.Length; i++)
+                cone[i].workDone = true;
+
+            if (stopped)
+                return;
+
+            if (!workEngine.B2StartBuffer(order.Seed, workSamplesCount))
+                return;
+
+            workEngine.AllJobsAdded();
+
+            // ONE barrier for the whole buffer (the wave path takes one per level).
+            if (!workEngine.AllDoneEvent().WaitOne(B2_WAIT_MS))
+            {
+                System.Threading.Interlocked.Increment(ref B2StallCount);
+                B2LastStall = workEngine.B2DescribePending();
+
+                // Drop to the wave path for the rest of the session rather than risk
+                // stalling again on the next buffer.
+                workEngine.B2Disable();
+                b2Installed = false;
+                b2Enabled = false;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]

--- a/ReBuzz/Audio/WorkThreadEngine.cs
+++ b/ReBuzz/Audio/WorkThreadEngine.cs
@@ -54,6 +54,43 @@ namespace ReBuzz.Audio
                             seen = generation;
                         }
 
+                        // B2 drain: pull ready INDICES until none are runnable, then park.
+                        // Parking on an empty ready list is correct even mid-buffer: any
+                        // machine still in flight will pulse the gate when it releases a
+                        // successor, and the dispatcher's wait is bounded regardless.
+                        if (b2Mode)
+                        {
+                            while (true)
+                            {
+                                if (stopped)
+                                    break;
+
+                                int idx = B2GetReady();
+                                if (idx < 0)
+                                    break;
+
+                                var bwi = b2Items[idx];
+                                try
+                                {
+                                    bwi.TickAndWork(nSamples, true);
+                                }
+                                catch (System.Exception ex)
+                                {
+                                    RecordFault(bwi.Machine?.Name, ex);
+                                }
+                                finally
+                                {
+                                    // MUST run for every dequeued index, on every path -
+                                    // throw, or TickAndWork's early return when !Ready.
+                                    // A machine that never releases its successors deadlocks
+                                    // the buffer. A faulted machine counts as completed with
+                                    // stale output for this chunk, exactly as wave mode does.
+                                    B2WorkDone(idx);
+                                }
+                            }
+                            continue;   // back to the gate
+                        }
+
                         while (true)
                         {
                             if (stopped)
@@ -117,6 +154,115 @@ namespace ReBuzz.Audio
             }
         }
 
+        // Install the dependency graph. TOPOLOGY-time only, never per buffer.
+        // succ carries one entry per EDGE (parallel/multi-channel connections repeat), so
+        // each successor's countdown is decremented exactly as many times as indeg counted.
+        internal void B2SetGraph(MachineWorkInstance[] items, int[] indeg, int[][] succ)
+        {
+            int n = items.Length;
+            int total = 0;
+            for (int i = 0; i < n; i++)
+                total += succ[i].Length;
+
+            var flat = new int[total];
+            var starts = new int[n];
+            var counts = new int[n];
+            int at = 0;
+            for (int i = 0; i < n; i++)
+            {
+                starts[i] = at;
+                counts[i] = succ[i].Length;
+                for (int j = 0; j < succ[i].Length; j++)
+                    flat[at++] = succ[i][j];
+            }
+
+            lock (workLock)
+            {
+                b2Items = items;
+                b2Indeg0 = indeg;
+                b2Remaining = new int[n];
+                b2SuccFlat = flat;
+                b2SuccStart = starts;
+                b2SuccCount = counts;
+                b2Mode = true;
+            }
+        }
+
+        // Diagnostic for the dispatcher's bounded wait: which machines never completed,
+        // and what their countdowns were stuck at. This is the difference between
+        // "the app froze" and "machine X is waiting on 1 input that never arrived".
+        internal string B2DescribePending()
+        {
+            var sb = new System.Text.StringBuilder();
+            lock (workLock)
+            {
+                sb.Append("pending=").Append(b2Pending)
+                  .Append(" ready=").Append(b2Ready.Count).Append(" stuck=[");
+                int shown = 0;
+                for (int i = 0; i < b2Remaining.Length && shown < 8; i++)
+                {
+                    if (b2Remaining[i] > 0)
+                    {
+                        if (shown > 0)
+                            sb.Append(", ");
+                        sb.Append(b2Items[i].Machine?.Name ?? "(null)")
+                          .Append(" waiting on ").Append(b2Remaining[i]);
+                        shown++;
+                    }
+                }
+                sb.Append("]");
+            }
+            return sb.ToString();
+        }
+
+        internal void B2Disable()
+        {
+            lock (workLock)
+            {
+                b2Mode = false;
+            }
+        }
+
+        // Per-buffer reset + seed. Called with the workers parked, same contract as
+        // AddWork. Returns false if there is nothing to do (caller must not wait).
+        internal bool B2StartBuffer(int[] seed, int samples)
+        {
+            nSamples = samples;
+            lock (workLock)
+            {
+                if (stopped)
+                    return false;
+
+                System.Array.Copy(b2Indeg0, b2Remaining, b2Indeg0.Length);
+                b2Pending = b2Indeg0.Length;
+                b2Ready.Clear();
+                allDoneHandle.Reset();
+
+                if (b2Pending == 0)
+                    return false;   // empty cone: nothing to wait for
+
+                for (int i = 0; i < seed.Length; i++)
+                    b2Ready.Add(seed[i]);
+
+                return true;
+            }
+        }
+
+        // Pop a ready cone index, or -1 if none are currently runnable. -1 does NOT mean
+        // the buffer is finished: successors may still be released by in-flight machines.
+        private int B2GetReady()
+        {
+            lock (workLock)
+            {
+                if (stopped || b2Ready.Count == 0)
+                    return -1;
+                int last = b2Ready.Count - 1;
+                int idx = b2Ready[last];
+                b2Ready.RemoveAt(last);
+                return idx;
+            }
+        }
+
         internal void AllJobsAdded()
         {
             // Open the wave: advance the generation and wake the workers. This is the
@@ -126,6 +272,54 @@ namespace ReBuzz.Audio
             {
                 generation++;
                 Monitor.PulseAll(gate);
+            }
+        }
+
+        // Release idx's successors, then account for the buffer. All of it under workLock
+        // so the countdown, the enqueue and the pending count move atomically together:
+        // a successor cannot be enqueued twice, and allDoneHandle cannot be set while
+        // newly-ready work is still unqueued.
+        private void B2WorkDone(int idx)
+        {
+            bool addedWork;
+            bool finished;
+
+            lock (workLock)
+            {
+                addedWork = false;
+                int start = b2SuccStart[idx];
+                int count = b2SuccCount[idx];
+                for (int k = 0; k < count; k++)
+                {
+                    int s = b2SuccFlat[start + k];
+                    if (--b2Remaining[s] == 0)
+                    {
+                        b2Ready.Add(s);
+                        addedWork = true;
+                    }
+                }
+
+                b2Pending--;
+                finished = (b2Pending == 0);
+
+                // Completion is b2Pending, never "ready list is empty": the list empties
+                // transiently mid-buffer whenever every runnable machine is in flight and
+                // none has released its successors yet. Only b2Pending tracks real progress.
+                if (finished)
+                    allDoneHandle.Set();
+            }
+
+            // The wake flag is a LOCAL, deliberately. A shared field would let two workers
+            // completing concurrently race on it and lose a wake, stranding ready work with
+            // every worker parked - a hung audio thread. Pulsing more often than strictly
+            // necessary is harmless: workers simply re-check the ready list.
+            if (addedWork && !finished)
+            {
+                lock (gate)
+                {
+                    generation++;
+                    Monitor.PulseAll(gate);
+                }
             }
         }
 
@@ -169,6 +363,40 @@ namespace ReBuzz.Audio
         private bool stopped;
         private int workCounter;
         private int nSamples;
+
+        // ==== B2 (#107): dependency-driven dispatch ===============================
+        // Wave mode: the dispatcher adds a whole DAG level, opens the gate, waits.
+        // Workers only POP. One barrier per level, so the buffer costs O(depth) barriers.
+        //
+        // B2 mode: the dispatcher seeds only the in-degree-zero machines, opens the gate
+        // ONCE and waits ONCE for the whole buffer. Workers also PUSH: on finishing
+        // machine i they decrement each successor's countdown and enqueue any that hit
+        // zero. A machine runs the moment ITS OWN inputs are done, not when its level is.
+        //
+        // Bit-identity: a machine still runs only after ALL its inputs have completed and
+        // sums them in connection-list order regardless of sibling timing - the same
+        // argument that makes wave mode order-independent.
+        //
+        // THE INVARIANT THAT MATTERS: every cone machine must complete EXACTLY ONCE.
+        // Complete twice and a successor is enqueued twice; complete zero times and its
+        // successors' countdowns never reach zero - either way the audio thread HANGS.
+        // It holds by construction here:
+        //   * an index enters b2Ready only when its countdown transitions to exactly 0,
+        //     under workLock, and a countdown reaches 0 once (it only ever decrements);
+        //   * an index is dequeued once (popped under workLock, never re-added);
+        //   * B2WorkDone runs in the worker's finally, so it fires even if TickAndWork
+        //     throws OR early-returns (it returns immediately when !Machine.Ready).
+        // The dispatcher additionally bounds its wait, so any residual stall surfaces as
+        // a log line rather than a frozen app.
+        private bool b2Mode;
+        private int[] b2Indeg0;                  // pristine in-degrees (topology-time)
+        private int[] b2Remaining;               // live countdown, reset per buffer
+        private int[] b2SuccFlat;                // successors, CSR-flattened (alloc-free)
+        private int[] b2SuccStart;
+        private int[] b2SuccCount;
+        private MachineWorkInstance[] b2Items;   // cone index -> work item
+        private readonly List<int> b2Ready = new List<int>();  // ready INDICES, not items
+        private int b2Pending;                   // cone machines not yet completed
 
         // Diagnostics for contained Work() faults (see the worker loop above).
         // Written only on the exceptional path, so there is no steady-state cost;


### PR DESCRIPTION
## What

Replaces the audio engine's **per-DAG-level barrier loop** with a **dependency-driven
dispatch**: one barrier per buffer instead of one per level.

The cached work order already computes, in its Kahn layering, exactly the structure needed —
per-machine in-degrees and successor edges — and then throws it away, keeping only the
flattened levels (`AudioWaves`). This PR keeps it. A machine now starts the instant *its own*
inputs finish, rather than waiting for its whole level to finish, so workers stay fed across
what used to be wave boundaries.

## Why

Barriers were the dominant cost. On the `det_grid_08x04` test song, the dispatch region is
**82–85% of the entire audio fill** — the engine spent most of its time coordinating work
rather than doing it.

## Results (measured, `det_grid_08x04`, algorithm 2 "Threads", cached order on, 8 audio threads, MT on)

| | audio fill | dispatch region | barriers/buffer |
|---|---|---|---|
| wave (before) | 2709.8 ms | 2302.3 ms | 4.00 |
| dependency (after) | **1870.5 ms** | **1530.5 ms** | **1.00** |

- **Whole audio fill: −31% (×1.45).** Dispatch region: −33.5%.
- **Barriers per buffer: 4.00 → 1.00** (the test song's audio cone is 4 levels deep).
- ~61 µs saved per barrier eliminated, consistent across two independent measurement runs.
- Also markedly **more stable**: fill-time sd 16.7 ms vs 136.8 ms. Fewer barriers, fewer
  chances to lose a thread-wake race.
- Separation is total: the slowest dependency-mode run beat the fastest wave-mode run.

n = 3 renders per arm, fresh launch each.

## Output is unchanged

Byte-identical renders (data-chunk md5) in both modes, MT on and MT off. This follows from
the dispatch order being irrelevant to the arithmetic: a machine still runs only after **all**
its inputs have completed, and it sums those inputs in connection-list order regardless of the
order its siblings were dispatched in — the same property that already made the wave dispatch
order-independent.

## How it's kept safe

The failure mode of a dependency countdown is a **stalled audio thread**, which no byte-gate
can catch. Three independent guards:

1. **The completion invariant holds by construction.** Every cone machine completes exactly
   once: an index enters the ready list only when its countdown transitions to zero (under the
   work lock, and a countdown reaches zero once because it only decrements); an index is
   dequeued once; and the completion call sits in the worker's `finally`, so it fires even when
   `TickAndWork` throws *or* early-returns (which it does whenever a machine is not `Ready`).
2. **`CachedWorkOrder.SelfCheck`** drains the new graph with the dispatcher's own rule at
   topology-build time and requires it to reproduce `AudioWaves` exactly — same machines, same
   layer assignment. `AudioWaves` already drives the shipping cached dispatch, so it is a sound
   oracle. On mismatch the dispatcher declines the new path and uses the wave path. Runs once
   per topology change, never per buffer.
3. **The dispatcher's wait is bounded** (2 s, against a sub-millisecond expectation). On
   timeout it records which machines failed to complete and what their countdowns were stuck
   at, disables the path, and falls back. A latent bug degrades instead of freezing.

Parallel (multi-channel) connections between the same pair are counted with multiplicity in
**both** in-degrees and successors, mirroring the existing Kahn drain — deduplicating them
would leave a countdown permanently above zero.

## Scope

Three files: `CachedWorkOrder.cs` (graph + self-check), `WorkThreadEngine.cs` (dependency
mode alongside the existing wave mode), `WorkManager.cs` (dispatcher + fallback). The wave
path is untouched and remains the fallback for cyclic graphs, self-check failures, and the
non-cached algorithms.

Builds on #129 (dispatcher-owned generation gate), whose gate is reused unchanged for the
single per-buffer "go".

## Caveats

- The saving scales with **DAG depth** (it removes `depth − 1` barriers per buffer). The test
  song's cone is 4 levels deep, so this is a modest case, not a best case; a flat graph would
  see no benefit.
- The dispatch/non-dispatch *split* is not perfectly comparable between the two arms, because
  the wave path runs single-machine levels inline on the dispatch thread. The whole-fill
  figure (−31%) is measured identically in both arms and is the honest end-to-end number.
