### PR TITLE
Add deadline-referenced audio dropout counter

### DIFF
--- a/ReBuzz/Audio/CommonAudioProvider.cs
+++ b/ReBuzz/Audio/CommonAudioProvider.cs
@@ -30,6 +30,12 @@ namespace ReBuzz.Audio
         private readonly int threadBufferSize;
         readonly EAudioThreadType threadType;
 
+        // Deadline-miss instrument (read by PP2 via ReBuzzCore accessors).
+        readonly System.Diagnostics.Stopwatch deadlineSw = System.Diagnostics.Stopwatch.StartNew();
+        readonly double deadlineTicksToMs = 1000.0 / System.Diagnostics.Stopwatch.Frequency;
+        readonly int deadlineSampleRate;
+        const double DeadlineWarmupMs = 1000.0;   // ignore startup priming misses
+
         public CommonAudioProvider(
           ReBuzzCore buzzCore,
           EngineSettings engineSettings,
@@ -41,6 +47,7 @@ namespace ReBuzz.Audio
             this.buzz = buzzCore;
             buzzCore.SelectedAudioDriverSampleRate = sampleRate;
             this.channels = channels;
+            deadlineSampleRate = sampleRate;
 
             threadBufferSize = bufferSize < 16 ? 16 : bufferSize * 2; // Stereo
             int size = doubleBuffer ? threadBufferSize * 2 : threadBufferSize; // Double buffer
@@ -179,6 +186,8 @@ namespace ReBuzz.Audio
                 return count;
             }
 
+            long deadlineStartTicks = deadlineSw.ElapsedTicks;
+
             int countRemaining = count / channels * 2;
 
             while (countRemaining > 0 && !stopped)
@@ -221,6 +230,18 @@ namespace ReBuzz.Audio
                     }
                     fillBufferNeed = threadBuffer.Length - threadBufferFillLevel;
                 }
+            }
+
+            // Did this callback overrun its OWN block period? Deadline is derived
+            // per-call from frames/sampleRate (the driver hands blocks far larger
+            // than the nominal buffer size, so the nominal size is the wrong number).
+            if (deadlineSampleRate > 0 && channels > 0)
+            {
+                long nowTicks = deadlineSw.ElapsedTicks;
+                double elapsedMs = (nowTicks - deadlineStartTicks) * deadlineTicksToMs;
+                double deadlineMs = (count / channels) / (double)deadlineSampleRate * 1000.0;
+                if (nowTicks * deadlineTicksToMs > DeadlineWarmupMs && elapsedMs > deadlineMs)
+                    ReBuzzCore.RecordDeadlineMiss((long)((elapsedMs - deadlineMs) * 1000.0));
             }
             return count;
         }

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -1843,8 +1843,31 @@ namespace ReBuzz.Core
         internal static void RecordDriverReset() =>
             System.Threading.Interlocked.Increment(ref DriverResets);
         public long DriverResetCount => DriverResets;
-        public void ResetAudioDropoutCounters() =>
+
+        // Deadline-referenced dropout counter. Unlike DriverResets (the device's own
+        // catastrophic-reset notification, which is blind to ordinary underruns), this
+        // counts audio callbacks whose wall-time exceeded their OWN block period
+        // (frames/sampleRate) — the real, per-callback playback deadline. Read by Pedal
+        // Profiler2 via reflection as DeadlineMissCount / DeadlineWorstOverrunMicros.
+        // Read is single-threaded (one driver-callback thread), so the worst-overrun
+        // max needs no CAS loop.
+        internal static long DeadlineMisses;
+        internal static long DeadlineWorstOverrunUs;
+        internal static void RecordDeadlineMiss(long overrunUs)
+        {
+            System.Threading.Interlocked.Increment(ref DeadlineMisses);
+            if (overrunUs > DeadlineWorstOverrunUs)
+                System.Threading.Interlocked.Exchange(ref DeadlineWorstOverrunUs, overrunUs);
+        }
+        public long DeadlineMissCount => DeadlineMisses;
+        public long DeadlineWorstOverrunMicros => DeadlineWorstOverrunUs;
+
+        public void ResetAudioDropoutCounters()
+        {
             System.Threading.Interlocked.Exchange(ref DriverResets, 0);
+            System.Threading.Interlocked.Exchange(ref DeadlineMisses, 0);
+            System.Threading.Interlocked.Exchange(ref DeadlineWorstOverrunUs, 0);
+        }
 
         public MachineCore CreateMaster()
         {


### PR DESCRIPTION
## Add a deadline-referenced audio dropout counter

### Problem

The only in-process dropout signal today is `DriverResetCount`, incremented from the
ASIO driver's own `DriverResetRequest` (and the WASAPI fault path). That surfaces a
**catastrophic device reset** (buffer/sample-rate/device change) — its handler even
tears down and re-creates the device. It does **not** fire on an ordinary buffer
underrun: ASIO has no standard per-underrun callback, so a glitchy-but-not-reset
session reads `DriverResetCount == 0`. There is no host-side signal that tracks
ordinary audible dropouts.

### What this adds

A second, deadline-referenced counter measured on the live audio callback path
(`CommonAudioProvider.Read`, which both the ASIO and WASAPI providers delegate to).
Each callback is wall-clock timed and compared against **its own block period**,
`(count / channels) / sampleRate` — the real per-callback deadline. If the call
overran, a counter increments and a worst-overrun high-water mark updates.

Deriving the deadline per-call is deliberate: the driver hands `Read` blocks far
larger than the nominal registry buffer size, so the nominal size is the wrong
reference. A 1 s startup warmup skips priming transients.

Exposed as two `public long` accessors alongside the existing one:

- `DeadlineMissCount`
- `DeadlineWorstOverrunMicros`

`ResetAudioDropoutCounters()` now clears these too.

### Cost / safety

- Two `Stopwatch.ElapsedTicks` reads plus a few FLOPs per callback (~tens to low
  hundreds per second). No allocation, no locks, no audio-thread I/O.
- The worst-overrun max is written by the single audio-callback thread, so it needs
  no CAS loop; the `long` accessors are read cross-thread (aligned 64-bit reads).

### Notes

- Two files: `ReBuzz/Core/ReBuzzCore.cs`, `ReBuzz/Audio/CommonAudioProvider.cs`.
- Additive and reflection-friendly (`public long` properties), so external tooling
  can read the counters without a compile-time dependency.
- The counter was validated out-of-band: a controlled positive-control run
  (injected callback stalls) confirmed it registers known deadline misses that
  `DriverResetCount` sleeps through, and a buffer-size sweep confirmed the miss rate
  tracks audible glitches by ear.
