### PR TITLE
ctrl+o/n/s is working again

### DIFF
--- a/ReBuzz/AppViews/MainWindow.xaml.cs
+++ b/ReBuzz/AppViews/MainWindow.xaml.cs
@@ -924,13 +924,13 @@ namespace ReBuzz
                             e.Handled = true;
                         }
                     }
-                    else if (e.Key == Key.Y)
+                    
+                    if (e.Key == Key.Y)
                     {
                         Buzz.ExecuteCommand(BuzzCommand.Redo);
                         e.Handled = true;
                     }
-                    
-                    if (e.Key == Key.S)
+                    else if (e.Key == Key.S)
                     {
                         Buzz.ExecuteCommand(BuzzCommand.SaveFile);
                         e.Handled = true;

--- a/ReBuzz/AppViews/MainWindow.xaml.cs
+++ b/ReBuzz/AppViews/MainWindow.xaml.cs
@@ -904,7 +904,8 @@ namespace ReBuzz
                         Buzz.ExecuteCommand(BuzzCommand.Redo);
                         e.Handled = true;
                     }
-                    else if (e.Key == Key.S)
+                    
+                    if (e.Key == Key.S)
                     {
                         Buzz.ExecuteCommand(BuzzCommand.SaveFile);
                         e.Handled = true;


### PR DESCRIPTION
Not sure when it happened but the ctrl+s/n/o were only in effect if the active view was `BuzzView.SongInfoView`. This made the e.g. save shortcut now work (at least for me). Not 100% sure if they are in the right place, maybe they should be inside the `if (Buzz.ActiveView != BuzzView.SongInfoView)` like copy/cut/paste?