### PR TITLE
Enable Multi‑Channel Recording

### DIFF
--- a/Machines/ReBuzzAudioOut/ReBuzzAudioOut.cs
+++ b/Machines/ReBuzzAudioOut/ReBuzzAudioOut.cs
@@ -104,7 +104,12 @@ namespace WDE.ReBuzzAudioOut
 					Command = new SimpleCommand()
 					{
 						CanExecuteDelegate = p => true,
-						ExecuteDelegate = p => MessageBox.Show("ReBuzz Audio Out 0.1 (C) 2024 WDE")
+						ExecuteDelegate = p => MessageBox.Show(@"ReBuzz Audio Out 0.1 (C) 2026 WDE
+
+Usage:
+1. Connect ReBuzz Audio Out to Master.
+2. Choose output channel from ReBuzz Audio Out menu.
+3. Connect machine(s) to ReBuzz Audio Out.")
 					}
 				};
 			}

--- a/ReBuzz/Audio/AudioEngine.cs
+++ b/ReBuzz/Audio/AudioEngine.cs
@@ -156,6 +156,10 @@ namespace ReBuzz.Audio
         {
             int frames = b.Frames;
             int channels = b.OutputChannelCount;
+            if (asioBuffer.Length < frames * channels)
+            {
+                asioBuffer = new float[frames * channels];
+            }
             Span<float> interleaved = asioBuffer.AsSpan(0, frames * channels);
 
             AudioWaveProvider.Read(interleaved);
@@ -594,6 +598,14 @@ namespace ReBuzz.Audio
             else if (AudioWaveProvider != null)
                 return AudioWaveProvider;
             else return null;
+        }
+
+        internal void ClearChannels()
+        {
+            if (AudioProvider != null)
+            {
+                (AudioProvider as IReBuzzAudioProvider).ClearChannels();
+            }
         }
     }
 }

--- a/ReBuzz/Audio/AudioProvider.cs
+++ b/ReBuzz/Audio/AudioProvider.cs
@@ -32,6 +32,11 @@ namespace ReBuzz.Audio
             AudioSampleProvider.ClearBuffer();
         }
 
+        public void ClearChannels()
+        {
+            AudioSampleProvider.ClearChannels();
+        }
+
         // Can be multi-channel
         public int Read(Span<float> buffer)
         {
@@ -44,9 +49,9 @@ namespace ReBuzz.Audio
         }
 
         // Always stereo
-        public int ReadOverride(float[] buffer, int offset, int count)
+        public int ReadOverride(float[] buffer, int offset, int count, bool multiChannel)
         {
-            return AudioSampleProvider.ReadOverride(buffer, offset, count);
+            return AudioSampleProvider.ReadOverride(buffer, offset, count, multiChannel);
         }
     }
 }

--- a/ReBuzz/Audio/AudioWaveProvider.cs
+++ b/ReBuzz/Audio/AudioWaveProvider.cs
@@ -32,6 +32,11 @@ namespace ReBuzz.Audio
             AudioSampleProvider.ClearBuffer();
         }
 
+        public void ClearChannels()
+        {
+            AudioSampleProvider.ClearChannels();
+        }
+
         public int Read(Span<float> floatBuffer)
         {
             int retCount = AudioSampleProvider.Read(floatBuffer);
@@ -44,9 +49,9 @@ namespace ReBuzz.Audio
             AudioSampleProvider.Stop();
         }
 
-        public int ReadOverride(float[] buffer, int offset, int count)
+        public int ReadOverride(float[] buffer, int offset, int count, bool multiChannel)
         {
-            return AudioSampleProvider.ReadOverride(buffer, offset, count);
+            return AudioSampleProvider.ReadOverride(buffer, offset, count, multiChannel);
         }
     }
 }

--- a/ReBuzz/Audio/CommonAudioProvider.cs
+++ b/ReBuzz/Audio/CommonAudioProvider.cs
@@ -1,13 +1,12 @@
 ﻿using Buzz.MachineInterface;
 using BuzzGUI.Common;
+using BuzzGUI.Common.Settings;
+using BuzzGUI.Interfaces;
+using ReBuzz.Audio.BurstProtection;
 using ReBuzz.Common;
 using ReBuzz.Core;
 using System;
 using System.Threading;
-using System.Threading.Tasks;
-using BuzzGUI.Common.Settings;
-using BuzzGUI.Interfaces;
-using ReBuzz.Audio.BurstProtection;
 
 namespace ReBuzz.Audio
 {
@@ -27,7 +26,7 @@ namespace ReBuzz.Audio
         int threadBufferFillLevel = 0;
         int threadBufferReadOffset = 0;
         private int fillBufferNeed;
-        private readonly int channels;
+        private readonly int outputChannels;
         private readonly int threadBufferSize;
         readonly EAudioThreadType threadType;
 
@@ -38,6 +37,8 @@ namespace ReBuzz.Audio
         const double DeadlineWarmupMs = 1000.0;   // ignore startup priming misses
 
         BurstProtectionEngine audioBurstProtection;
+        readonly int maxStereoChannelCount = 32;
+        public int MaxStereoChannelCount => maxStereoChannelCount;
 
         public CommonAudioProvider(
           ReBuzzCore buzzCore,
@@ -49,7 +50,7 @@ namespace ReBuzz.Audio
         {
             this.buzz = buzzCore;
             buzzCore.SelectedAudioDriverSampleRate = sampleRate;
-            this.channels = channels;
+            this.outputChannels = channels;
             deadlineSampleRate = sampleRate;
 
             threadBufferSize = bufferSize < 16 ? 16 : bufferSize * 2; // Stereo
@@ -58,12 +59,12 @@ namespace ReBuzz.Audio
             threadBuffer = new float[size];
             fillBuffer = new float[size];
 
-            fillBufferChannel = new float[64][];
-            for (int i = 0; i < 64; i++)
+            fillBufferChannel = new float[maxStereoChannelCount][];
+            for (int i = 0; i < maxStereoChannelCount; i++)
                 fillBufferChannel[i] = new float[size];
 
-            threadBufferChannel = new float[64][];
-            for (int i = 0; i < 64; i++)
+            threadBufferChannel = new float[maxStereoChannelCount][];
+            for (int i = 0; i < maxStereoChannelCount; i++)
                 threadBufferChannel[i] = new float[size];
 
             long processorAffinityMask = registryEx.Read("ProcessorAffinity", 0xFFFFFFFF, "Settings");
@@ -126,7 +127,18 @@ namespace ReBuzz.Audio
             threadBufferWriteOffset = 0;
         }
 
+        internal void ClearChannels()
+        {
+            for (int i = 1; i < outputChannels / 2; i++)
+            {
+                Array.Clear(fillBufferChannel[i], 0, fillBufferChannel[i].Length);
+            }
+        }
+
         private readonly Lock bufferLock = new();
+
+        public int OutputChannels => outputChannels;
+
         private int FillTheBuffer(int readSize)
         {
             lock (bufferLock)
@@ -155,7 +167,7 @@ namespace ReBuzz.Audio
                     Buffer.BlockCopy(fillBuffer, offset << 2, threadBuffer, threadBufferWriteOffset << 2, count << 2);
 
                     // Copy other output channels
-                    int stereoOutChannels = channels / 2;
+                    int stereoOutChannels = OutputChannels / 2;
                     for (int j = 1; j < stereoOutChannels; j++)
                     {
                         var fromBuffer = fillBufferChannel[j];
@@ -193,8 +205,8 @@ namespace ReBuzz.Audio
             }
 
             // count is in floats; convert to stereo frames (L,R) per output channel pair
-            int stereoChannels = channels / 2;
-            int framesRequested = count / channels; // frames per all channels
+            int stereoChannels = OutputChannels / 2;
+            int framesRequested = count / OutputChannels; // frames per all channels
             int samplesRequested = framesRequested * 2; // L,R per frame in threadBuffer
 
             int countRemaining = samplesRequested;
@@ -206,13 +218,13 @@ namespace ReBuzz.Audio
                 lock (bufferLock)
                 {
                     int readCount = Math.Min(countRemaining, threadBufferFillLevel);
+                    float audioOutMul = 1 / 32768.0f;
 
                     if (threadBufferReadOffset + readCount > threadBuffer.Length)
                         readCount = threadBuffer.Length - threadBufferReadOffset;
 
                     if (readCount > 0)
                     {
-
                         audioBurstProtection.Process(threadBuffer, threadBufferReadOffset, readCount, true, false);
 
                         for (int j = 1; j < stereoChannels; j++)
@@ -232,8 +244,8 @@ namespace ReBuzz.Audio
                             for (int j = 1; j < stereoChannels; j++)
                             {
                                 var chBuf = threadBufferChannel[j];
-                                buffer[offset++] = chBuf[threadBufferReadOffset];
-                                buffer[offset++] = chBuf[threadBufferReadOffset + 1];
+                                buffer[offset++] = chBuf[threadBufferReadOffset] * audioOutMul;         // Scale other channels to match required output
+                                buffer[offset++] = chBuf[threadBufferReadOffset + 1] * audioOutMul;
                             }
 
                             threadBufferReadOffset += 2;
@@ -261,15 +273,16 @@ namespace ReBuzz.Audio
             // Did this callback overrun its OWN block period? Deadline is derived
             // per-call from frames/sampleRate (the driver hands blocks far larger
             // than the nominal buffer size, so the nominal size is the wrong number).
-            if (deadlineSampleRate > 0 && channels > 0)
+            if (deadlineSampleRate > 0 && OutputChannels > 0)
             {
                 long nowTicks = deadlineSw.ElapsedTicks;
                 double elapsedMs = (nowTicks - deadlineStartTicks) * deadlineTicksToMs;
-                double deadlineMs = (count / channels) / (double)deadlineSampleRate * 1000.0;
+                double deadlineMs = (count / OutputChannels) / (double)deadlineSampleRate * 1000.0;
                 if (nowTicks * deadlineTicksToMs > DeadlineWarmupMs && elapsedMs > deadlineMs)
                     ReBuzzCore.RecordDeadlineMiss((long)((elapsedMs - deadlineMs) * 1000.0));
             }
-            return count - (countRemaining * channels / 2);
+
+            return count - (countRemaining * stereoChannels);
         }
 
         public void Stop()
@@ -297,28 +310,77 @@ namespace ReBuzz.Audio
             audioBurstProtection.Release();
         }
 
-        internal int ReadOverride(float[] buffer, int offset, int count)
+        public int FillBufferForMultiChannelMasterTap(
+            float[] buffer,
+            float[] samples,
+            int offset,
+            int count)
         {
-            return workManager.MainAudioFillBuffer(buffer, offset, count);
+            int stereoChannels = buzz.MasterTapChannelCount / 2;    // number of stereo pairs
+            int frames = count / 2;                                 // number of frames to write
+
+            int writeOffset = 0;
+            int frameOffset = offset / 2;                           // convert float offset → frame offset
+
+            for (int f = 0; f < frames; f++)
+            {
+                int sampleIndex = (frameOffset + f) * 2;            // L,R index in samples[]
+
+                // main stereo pair
+                buffer[writeOffset++] = samples[sampleIndex];
+                buffer[writeOffset++] = samples[sampleIndex + 1];
+
+                // additional stereo pairs
+                for (int j = 1; j < stereoChannels; j++)
+                {
+                    var chBuf = fillBufferChannel[j];
+                    buffer[writeOffset++] = chBuf[sampleIndex];
+                    buffer[writeOffset++] = chBuf[sampleIndex + 1];
+                }
+            }
+
+            return count; // number of floats written
+        }
+
+        internal int ReadOverride(float[] buffer, int offset, int count, bool multiChannel = false)
+        {
+            int readCount;
+
+            if (multiChannel)
+            {
+                readCount = count;
+                // count is in floats; convert to stereo frames (L,R) per output channel pair
+                int framesRequested = count / buzz.MasterTapChannelCount; // frames per all channels
+                int mainStereoSamplesRequested = framesRequested * 2; // L,R per frame in 
+
+                workManager.MainAudioFillBuffer(buffer, offset, mainStereoSamplesRequested);
+            }
+            else
+            {
+                readCount = workManager.MainAudioFillBuffer(buffer, offset, count);
+            }
+
+            return readCount;
         }
 
         internal void FillChannel(int channel, Sample[] samples, int n)
         {
             // First channel (0) is the main stereo out
-            if (channel < 1 || channel >= channels / 2 || channel >= 64)
+            if (channel < 1 || channel >= maxStereoChannelCount)
                 return;
 
             var fillChannel = fillBufferChannel[channel];
             var workBufferOffset = workManager.workBufferOffset;    // Ugly, but we need to know where to write
             int j = 0;
-            float audioOutMul = 1 / 32768.0f;
-
+            
             if (buzz.Speed == 0)
             {
                 for (int i = 0; i < n; i++)
                 {
-                    fillChannel[j++ + workBufferOffset] += samples[i].L * audioOutMul;
-                    fillChannel[j++ + workBufferOffset] += samples[i].R * audioOutMul;
+                    fillChannel[workBufferOffset + j] += samples[i].L;
+                    fillChannel[workBufferOffset + j + 1] += samples[i].R;
+
+                    j += 2;
                 }
             }
             else
@@ -342,7 +404,7 @@ namespace ReBuzz.Audio
 
                 for (int i = 0; i < targetCount; i++)
                 {
-                    fillChannel[i + workBufferOffset] += toBuffer[i] * audioOutMul;
+                    fillChannel[i + workBufferOffset] += toBuffer[i];
                 }
             }
         }

--- a/ReBuzz/Audio/IReBuzzAudioProvider.cs
+++ b/ReBuzz/Audio/IReBuzzAudioProvider.cs
@@ -2,8 +2,9 @@
 {
     internal interface IReBuzzAudioProvider
     {
-        int ReadOverride(float[] buffer, int offset, int count);
+        int ReadOverride(float[] buffer, int offset, int count, bool multiChannel);
         void ClearBuffer();
+        void ClearChannels();
         CommonAudioProvider AudioSampleProvider { get; }
     }
 }

--- a/ReBuzz/Audio/WorkManager.cs
+++ b/ReBuzz/Audio/WorkManager.cs
@@ -134,6 +134,8 @@ namespace ReBuzz.Audio
             {
                 long time = Stopwatch.GetTimestamp();
 
+                buzzCore.AudioEngine.ClearChannels();
+
                 multiThreadingEnabled = engineSettings.Multithreading;
 
                 var subTickInfo = ReBuzzCore.subTickInfo;
@@ -144,7 +146,7 @@ namespace ReBuzz.Audio
 
                 while (reminingBuffer > 0)
                 {   
-                    int samplesToProcess = Math.Min(reminingBuffer / 2, 256);
+                    int framesToProcess = Math.Min(reminingBuffer / 2, 256);
 
                     // More accurate samples per tick?
                     //if (engineSettings.AccurateBPM)
@@ -166,26 +168,26 @@ namespace ReBuzz.Audio
                     // HandleParameterRecord();
 
                     // Ensure we don't go over tick
-                    if (masterInfo.PosInTick + samplesToProcess > masterInfo.SamplesPerTick)
+                    if (masterInfo.PosInTick + framesToProcess > masterInfo.SamplesPerTick)
                     {
                         // Make sure tick will be zero
-                        samplesToProcess = masterInfo.SamplesPerTick - masterInfo.PosInTick;
-                        if (samplesToProcess < 0)
+                        framesToProcess = masterInfo.SamplesPerTick - masterInfo.PosInTick;
+                        if (framesToProcess < 0)
                             return 0;
                     }
 
                     // Ensure we don't go over subtick
                     if (engineSettings.SubTickTiming && 
-                        subTickInfo.PosInSubTick + samplesToProcess > subTickInfo.SamplesPerSubTick)
+                        subTickInfo.PosInSubTick + framesToProcess > subTickInfo.SamplesPerSubTick)
                     {
                         // Make sure tick will be zero
-                        samplesToProcess = subTickInfo.SamplesPerSubTick - subTickInfo.PosInSubTick;
-                        if (samplesToProcess < 0)
+                        framesToProcess = subTickInfo.SamplesPerSubTick - subTickInfo.PosInSubTick;
+                        if (framesToProcess < 0)
                             return 0;
                     }
 
                     // Call Pattern Column Events
-                    UpdatePatternColumnEvents(samplesToProcess);
+                    UpdatePatternColumnEvents(framesToProcess);
 
                     // Update Managed Machine host info
                     buzzCore.MachineManager.UpdateMasterAndSubTickInfoToHost();
@@ -194,19 +196,19 @@ namespace ReBuzz.Audio
                     CallTick();
 
                     // Call work
-                    ReadWork(buffer, workBufferOffset, samplesToProcess);
+                    ReadWork(buffer, workBufferOffset, framesToProcess);
 
                     // Mix waves playing from wavetable 
                     if (buzzCore.SongCore.WavetableCore.IsPlayingWave())
                     {
-                        buzzCore.SongCore.WavetableCore.GetPlayWaveSamples(playWaveBuffer, offset, samplesToProcess);
+                        buzzCore.SongCore.WavetableCore.GetPlayWaveSamples(playWaveBuffer, offset, framesToProcess);
                         // Elementwise multiply-add in single precision with the
                         // same two per-element roundings as the scalar loop
                         // (separate * then +, matching operand order; RyuJIT
                         // performs no FP contraction, so neither form uses FMA;
                         // no reduction) => bit-exact. ("wvw" to avoid CS0136
                         // with the output-scale block's "vw" below.)
-                        int n = samplesToProcess * 2;
+                        int n = framesToProcess * 2;
                         Vector<float> waveMulVec = new Vector<float>(32768.0f);
                         int wvw = Vector<float>.Count;
                         int i = 0;
@@ -223,13 +225,14 @@ namespace ReBuzz.Audio
                     }
 
                     // Master Tap
-                    buzzCore.MasterTapSamples(buffer, workBufferOffset, samplesToProcess * 2);
+                    buzzCore.MasterTapSamples(buffer, workBufferOffset, framesToProcess * 2);
+                    buzzCore.MasterTapSamplesMultiChannel(buffer, workBufferOffset, framesToProcess * 2);
 
-                    workBufferOffset += samplesToProcess * 2;
-                    reminingBuffer -= samplesToProcess * 2;
+                    workBufferOffset += framesToProcess * 2;
+                    reminingBuffer -= framesToProcess * 2;
 
-                    subTickInfo.PosInSubTick += samplesToProcess;
-                    masterInfo.PosInTick += samplesToProcess;
+                    subTickInfo.PosInSubTick += framesToProcess;
+                    masterInfo.PosInTick += framesToProcess;
 
                     if (subTickInfo.PosInSubTick >= subTickInfo.SamplesPerSubTick)
                     {
@@ -253,10 +256,10 @@ namespace ReBuzz.Audio
                     }
 
                     // Update position info in patterns
-                    UpdatePatternPositions(samplesToProcess);
+                    UpdatePatternPositions(framesToProcess);
 
                     // Update frame count
-                    unchecked { ReBuzzCore.GlobalState.AudioFrame++; }
+                    unchecked { ReBuzzCore.GlobalState.AudioFrame += framesToProcess; }
                 }
 
                 float audioOutMul = 1 / 32768.0f;

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -30,6 +30,7 @@ using System.Printing;
 using System.Reflection;
 using System.Runtime;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -37,6 +38,7 @@ using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
 using System.Xml.Linq;
+using Windows.Services.Maps.LocalSearch;
 using Timer = System.Timers.Timer;
 
 namespace ReBuzz.Core
@@ -176,6 +178,8 @@ namespace ReBuzz.Core
         internal MidiControllerAssignments MidiControllerAssignments { get; set; }
 
         internal DispatcherTimer dtEngineThread;
+
+        public int OutputChannels { get => AudioEngine.GetAudioProvider().AudioSampleProvider.OutputChannels; }
 
         int speed;
         bool playing;
@@ -665,6 +669,7 @@ namespace ReBuzz.Core
         public event Action PatternEditorActivated;
         public event Action SequenceEditorActivated;
         public event Action<float[], bool, SongTime> MasterTap;
+        public event Action<float[], int, SongTime> MasterTapMultiChannel;
 
         // ─── MasterTap double-buffer (avoid a per-sub-chunk alloc) ───────────
         // The tap copy escapes to the GUI thread via BeginInvoke and is read
@@ -1430,7 +1435,18 @@ namespace ReBuzz.Core
             var ap = AudioEngine.GetAudioProvider();
             if (ap != null)
             {
-                ap.ReadOverride(buffer, 0, nsamples);
+                ap.ReadOverride(buffer, 0, nsamples, false);
+                return nsamples;
+            }
+            return 0;
+        }
+
+        public int RenderAudioMultiChannel(float[] buffer, int nsamples, int samplerate)
+        {
+            var ap = AudioEngine.GetAudioProvider();
+            if (ap != null)
+            {
+                ap.ReadOverride(buffer, 0, nsamples, true);
                 return nsamples;
             }
             return 0;
@@ -1701,6 +1717,29 @@ namespace ReBuzz.Core
                 }
             });
         }
+
+        internal void MasterTapSamplesMultiChannel(float[] samples, int offset, int count)
+        {
+            if (MasterTapMultiChannel != null)
+            {
+                var s = GetSongTime();
+                float[] resSamples = new float[count * MasterTapChannelCount / 2];
+                AudioEngine.GetAudioProvider().AudioSampleProvider.FillBufferForMultiChannelMasterTap(resSamples, samples, offset, count);
+                dispatcher.BeginInvoke(() =>
+                {
+                    try
+                    {
+                        MasterTapMultiChannel?.Invoke(resSamples, MasterTapChannelCount, s);
+                    }
+                    finally
+                    {
+                    }
+                });
+            }
+        }
+
+        int masterTapChannelCount = 2;
+        public int MasterTapChannelCount { get => masterTapChannelCount; set { masterTapChannelCount = Math.Max(2, Math.Min(AudioEngine.GetAudioProvider().AudioSampleProvider.MaxStereoChannelCount * 2, value)); PropertyChanged.Raise(this, "MasterTapChannelCount"); } }
 
         internal MachineCore CloneMachine(MachineCore machineToClone, float x, float y)
         {
@@ -2214,10 +2253,14 @@ namespace ReBuzz.Core
             AudioReceived?.Invoke(samples, n);
         }
 
+        Lock audioOutLock = new();
         public void AudioOut(int channel, Sample[] samples, int n)
         {
-            var AudioProvider = AudioEngine.GetAudioProvider();
-            AudioProvider?.AudioSampleProvider.FillChannel(channel, samples, n);
+            lock (audioOutLock)
+            {
+                var AudioProvider = AudioEngine.GetAudioProvider();
+                AudioProvider?.AudioSampleProvider.FillChannel(channel, samples, n);
+            }
         }
 
         internal bool SetEditorMachineForCurrent(IMachineDLL editorMachine)

--- a/ReBuzzGUI/BuzzGUI.Interfaces/IBuzz.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/IBuzz.cs
@@ -84,6 +84,7 @@ namespace BuzzGUI.Interfaces
         void ConfigureAudioDriver();
 
         int RenderAudio(float[] buffer, int nsamples, int samplerate);      // can be called when OverrideAudioDriver == true
+        int RenderAudioMultiChannel(float[] buffer, int nsamples, int samplerate); // can be called when OverrideAudioDriver == true
 
         IMachine GetIMachineFromCMachinePtr(IntPtr pmac);
 
@@ -104,6 +105,14 @@ namespace BuzzGUI.Interfaces
         // callback. Handlers that retain it (queue it, hand it to another
         // thread) must copy it first ((float[])samples.Clone()). See #122/#125.
         event Action<float[], bool, SongTime> MasterTap;
+
+        // Samples, channels, SongTime
+        event Action<float[], int, SongTime> MasterTapMultiChannel;
+
+        public int MasterTapChannelCount { get; set; }
+
+        // Audio interface outputs.
+        public int OutputChannels { get; }
 
         // Extensions
         void SetModifiedFlag();

--- a/ReBuzzGUI/BuzzGUI.MachineView/HDRecorder/HDRecorderWindow.xaml
+++ b/ReBuzzGUI/BuzzGUI.MachineView/HDRecorder/HDRecorderWindow.xaml
@@ -8,6 +8,7 @@
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
 		</Grid.RowDefinitions>
 
@@ -16,6 +17,7 @@
 				<ColumnDefinition Width="Auto"/>
 				<ColumnDefinition Width="*"/>
 				<ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
 			</Grid.ColumnDefinitions>
 		
 			<Button Grid.Column="0" Width="60" Height="22" Command="{Binding SaveAsCommand}" IsEnabled="{Binding SettingsGUIEnabled}">Save As...</Button>
@@ -29,15 +31,21 @@
                     </ContextMenu>
                 </TextBlock.ContextMenu>
             </TextBlock>
-            <ComboBox Grid.Column="2" HorizontalAlignment="Right" Width="70" SelectedIndex="{Binding BitDepthIndex}" ToolTip="Bit Depth">
-				<ComboBoxItem Content="int16"/>
-				<ComboBoxItem Content="int24"/>
-				<ComboBoxItem Content="int32"/>
-				<ComboBoxItem Content="float32"/>
-			</ComboBox>
+
 		</Grid>
-		
-		<StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,8,0,0">
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Right">
+            <TextBlock Text="Channel Count: " ToolTip="Multi-Channel" Margin="4,0,0,0"></TextBlock>
+            <ComboBox Name="cbMultiChannel" HorizontalAlignment="Right" Margin="0,0,4,0" Width="100" ItemsSource="{Binding MultiChannelItems}" SelectedIndex="{Binding MultiChannelListIndex}" ToolTip=""></ComboBox>
+            <ComboBox HorizontalAlignment="Right" Width="70" SelectedIndex="{Binding BitDepthIndex}" ToolTip="Bit Depth">
+                <ComboBoxItem Content="int16"/>
+                <ComboBoxItem Content="int24"/>
+                <ComboBoxItem Content="int32"/>
+                <ComboBoxItem Content="float32"/>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
 			<Button Width="100" Height="22" Content="Record"  Command="{Binding RecordCommand}" IsEnabled="{Binding IsNotRecording}"/>
 			<Button Width="100" Height="22" Margin="4,0,0,0" Content="Record Loop" Command="{Binding RecordLoopCommand}" IsEnabled="{Binding IsNotRecording}"/>
 			<Button Width="100" Height="22" Margin="4,0,0,0" Content="Render Loop" Command="{Binding RenderLoopCommand}" IsEnabled="{Binding IsNotRecording}"/>
@@ -45,7 +53,7 @@
 			<Button Width="61.99" Height="22" Margin="4,0,0,0" Content="Stop" Command="{Binding StopCommand}" IsEnabled="{Binding IsRecording}"/>
 		</StackPanel>
 	
-		<ProgressBar Name="progress" Grid.Row="2" Height="22" Margin="0,8,0,0" IsEnabled="False"/>
+		<ProgressBar Name="progress" Grid.Row="3" Height="22" Margin="0,8,0,0" IsEnabled="False"/>
 
 	</Grid>
 </Window>

--- a/ReBuzzGUI/BuzzGUI.MachineView/HDRecorder/HDRecorderWindow.xaml.cs
+++ b/ReBuzzGUI/BuzzGUI.MachineView/HDRecorder/HDRecorderWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using BuzzGUI.Common;
+﻿using Buzz.MachineInterface;
+using BuzzGUI.Common;
 using BuzzGUI.Common.DSP;
 using BuzzGUI.Interfaces;
 using libsndfile;
@@ -27,6 +28,12 @@ namespace BuzzGUI.MachineView.HDRecorder
 
         IBuzz buzz;
         IMachineGraph machineGraph;
+
+        List<MultiChannelItem> multiChannelItems;
+        public List<MultiChannelItem> MultiChannelItems { get => multiChannelItems; set { multiChannelItems = value; PropertyChanged.Raise(this, "MultiChannelItems"); } }
+
+        int multiChannelListIndex = 0;
+        public int MultiChannelListIndex { get => multiChannelListIndex; set { multiChannelListIndex = value; cbMultiChannel.ToolTip = MultiChannelItems?[multiChannelListIndex].ToString(); PropertyChanged.Raise(this, "MultiChannelListIndex"); } }
 
         public IMachineGraph MachineGraph
         {
@@ -92,6 +99,8 @@ namespace BuzzGUI.MachineView.HDRecorder
                 PropertyChanged.Raise(this, "IsNotRecording");
             }
         }
+
+        int recordingChannelCount = 2;
 
         public bool IsNotRecording { get { return !IsRecording; } }
 
@@ -228,6 +237,16 @@ namespace BuzzGUI.MachineView.HDRecorder
                 Stop();
             };
 
+            MultiChannelItems =
+            [
+                new MultiChannelItem() { ChannelType = MultiChannelType.Stereo, ChannelCount = 2 },
+                new MultiChannelItem() { ChannelType = MultiChannelType.AudioInterfaceOutputCount, ChannelCount = Global.Buzz.OutputChannels },
+            ];
+            for (int i = 4; i <= 32; i += 2)
+            {
+                MultiChannelItems.Add(new MultiChannelItem() { ChannelType = MultiChannelType.Range, ChannelCount = i });
+            }
+            MultiChannelListIndex = 0;
         }
 
         // Remove the runnning digit
@@ -261,7 +280,12 @@ namespace BuzzGUI.MachineView.HDRecorder
         {
             var bitdepths = new[] { Format.SF_FORMAT_PCM_16, Format.SF_FORMAT_PCM_24, Format.SF_FORMAT_PCM_32, Format.SF_FORMAT_FLOAT };
 
-            var soundFile = SoundFile.Create(OutputPath, buzz.SelectedAudioDriverSampleRate, 2, Format | bitdepths[BitDepthIndex]);
+            SoundFile soundFile = null;
+
+            recordingChannelCount = multiChannelItems[MultiChannelListIndex].ChannelCount;
+            Global.Buzz.MasterTapChannelCount = recordingChannelCount;
+            soundFile = SoundFile.Create(OutputPath, buzz.SelectedAudioDriverSampleRate, multiChannelItems[MultiChannelListIndex].ChannelCount, Format | bitdepths[BitDepthIndex]);
+
             soundFile.Clipping = true;
 
             bufferQueue = new BlockingCollection<float[]>();
@@ -273,8 +297,9 @@ namespace BuzzGUI.MachineView.HDRecorder
                     try
                     {
                         var samples = bufferQueue.Take();
+
                         DSP.Scale(samples, 1.0f / 32768.0f);
-                        soundFile.WriteFloat(samples, 0, samples.Length / 2);
+                        soundFile.WriteFloat(samples, 0, samples.Length / recordingChannelCount);
                     }
                     catch (InvalidOperationException) { }
                 }
@@ -302,7 +327,8 @@ namespace BuzzGUI.MachineView.HDRecorder
             prepareCount = 0;
             state = States.Recording;
 
-            buzz.MasterTap += Buzz_MasterTap;
+            buzz.MasterTapMultiChannel += Buzz_MasterTapMultiChannel;
+
             IsRecording = true;
         }
 
@@ -327,7 +353,7 @@ namespace BuzzGUI.MachineView.HDRecorder
             prepareCount = prepcount;
             state = States.WaitingForStart;
 
-            buzz.MasterTap += Buzz_MasterTap;
+            buzz.MasterTapMultiChannel += Buzz_MasterTapMultiChannel;
 
             buzz.Playing = true;
             IsRecording = true;
@@ -338,24 +364,31 @@ namespace BuzzGUI.MachineView.HDRecorder
 
                 driveTask = Task.Factory.StartNew(() =>
                 {
-
                     var buffer = new float[2 * 256];
                     while (!cts.Token.IsCancellationRequested)
                     {
-                        System.Threading.Thread.Sleep(0);
+                        Thread.Sleep(0);
 
                         for (int i = 0; i < 10; i++)
-                            buzz.RenderAudio(buffer, 256, buzz.SelectedAudioDriverSampleRate);
+                        {
+                            buzz.RenderAudioMultiChannel(buffer, 256, buzz.SelectedAudioDriverSampleRate);
+                        }
                     }
 
                     buzz.OverrideAudioDriver = false;
                 });
             }
-
-
         }
 
-        void Buzz_MasterTap(float[] samples, bool stereo, SongTime songtime)
+        private void Buzz_MasterTapMultiChannel(float[] samples, int channels, SongTime songtime)
+        {
+            if (channels != recordingChannelCount)
+                return;
+
+            HandleMasterTapData(samples, songtime);
+        }
+
+        void HandleMasterTapData(float[] samples, SongTime songtime)
         {
             bool juststarted = false;
 
@@ -392,7 +425,6 @@ namespace BuzzGUI.MachineView.HDRecorder
             {
                 bufferQueue.Add((float[])samples.Clone()); // own a copy: MasterTap reuse buffer is recycled after this returns (#122)
             }
-
         }
 
         void Stop()
@@ -400,7 +432,7 @@ namespace BuzzGUI.MachineView.HDRecorder
             if (!IsRecording) return;
 
             IsRecording = false;
-            buzz.MasterTap -= Buzz_MasterTap;
+            buzz.MasterTapMultiChannel -= Buzz_MasterTapMultiChannel;
             if (buzz.Playing) buzz.Playing = false;
             progress.Value = 0;
             progress.IsEnabled = false;
@@ -427,5 +459,32 @@ namespace BuzzGUI.MachineView.HDRecorder
         public event PropertyChangedEventHandler PropertyChanged;
 
         #endregion
+    }
+
+    public enum MultiChannelType
+    {
+        Stereo,
+        AudioInterfaceOutputCount,
+        Range
+    }
+
+    public class MultiChannelItem
+    {
+        public MultiChannelType ChannelType { get; set; }
+        public int ChannelCount { get; set; }
+        public override string ToString()
+        {
+            switch (ChannelType)
+            {
+                case MultiChannelType.Stereo:
+                    return "Stereo";
+                case MultiChannelType.AudioInterfaceOutputCount:
+                    return "Audio Interface Output Channel Count";
+                case MultiChannelType.Range:
+                    return "Channels 0 - " + ChannelCount;
+                default:
+                    return "";
+            }
+        }
     }
 }


### PR DESCRIPTION
Enable Multi‑Channel Recording

This update adds support for recording multiple audio channels independently through the Hard Disk Recorder.

Usage

1. Connect ReBuzz Audio Out to Master.
This routes the machine’s output into the main audio path.

2. Select an output channel from the ReBuzz Audio Out menu.
Each instance can now target a specific channel.

3. Connect machine(s) to ReBuzz Audio Out.
Machines routed through different ReBuzz Audio Out instances will be recorded on separate channels.

After configuring the routing, open the Hard Disk Recorder and record using the selected multi‑channel setup.