### PR TITLE
Enable multi‑channel audio input

### DIFF
--- a/Machines/ReBuzzAudioIn/ReBuzzAudioIn.cs
+++ b/Machines/ReBuzzAudioIn/ReBuzzAudioIn.cs
@@ -1,21 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.ComponentModel;
-using System.Collections.ObjectModel;
 using Buzz.MachineInterface;
 using BuzzGUI.Interfaces;
 using BuzzGUI.Common;
-using NAudio.Wave;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using BuzzGUI.Common.Templates;
-using NAudio;
-using libsndfile;
 
 namespace WDE.ReBuzzAudioIn
 {
@@ -24,7 +13,7 @@ namespace WDE.ReBuzzAudioIn
 	{
 		IBuzzMachineHost host;
         float[] recordBuffer;
-		int writeBufferPointer;
+		int writeStereoBufferPointer;
 		int readBufferPointer;
 		int bufferFillLevel = 0;
 
@@ -43,7 +32,7 @@ namespace WDE.ReBuzzAudioIn
 				ReleaseCapture();
 
                 bufferFillLevel = 0;
-                writeBufferPointer = 0;
+                writeStereoBufferPointer = 0;
                 readBufferPointer = 0;
 
                 int bufferSize = machineState.BufferSize * 2;
@@ -53,28 +42,54 @@ namespace WDE.ReBuzzAudioIn
             }
         }
 
-        private void Buzz_AudioReceived(float[] buffer, int n)
+        private void Buzz_AudioReceived(float[] buffer, int frames, int channels)
         {
-			lock (bufferLock)
-			{
-				int countRemaining = n;
-				int bufferOffset = 0;
-				while (countRemaining > 0)
-				{
-					int count = countRemaining;
-					if (writeBufferPointer + count > recordBuffer.Length)
-					{
-						count = recordBuffer.Length - writeBufferPointer;
+            lock (bufferLock)
+            {
+                int stereoChannels = channels >> 1;
+                int pairIndex = Math.Min(stereoChannels - 1, Math.Max(machineState.Channel, 0));
+
+                int chL = pairIndex * 2;
+                int chR = chL + 1;
+
+                int framesRemaining = frames;
+                int bufferFrameOffset = 0;
+
+                while (framesRemaining > 0)
+                {
+                    int frameCount = framesRemaining;
+
+                    // How many stereo samples fit before wrap?
+                    int samplesAvailable = recordBuffer.Length - writeStereoBufferPointer;
+                    int framesAvailable = samplesAvailable / 2;
+
+                    if (frameCount > framesAvailable)
+                        frameCount = framesAvailable;
+
+                    // Copy selected stereo pair
+                    int writePos = writeStereoBufferPointer;
+
+                    for (int i = 0; i < frameCount; i++)
+                    {
+                        int srcFrame = bufferFrameOffset + i;
+                        int srcBase = srcFrame * channels;
+
+                        recordBuffer[writePos] = buffer[srcBase + chL];
+                        recordBuffer[writePos + 1] = buffer[srcBase + chR];
+
+                        writePos += 2;
                     }
 
-					Buffer.BlockCopy(buffer, bufferOffset * 4, recordBuffer, writeBufferPointer * 4, count * 4);
-					writeBufferPointer += count;
-					bufferOffset += count;
+                    writeStereoBufferPointer = writePos;
 
-					if (writeBufferPointer == recordBuffer.Length)
-						writeBufferPointer = 0;
-					countRemaining -= count;
-					bufferFillLevel += count;
+                    // Wrap if needed
+                    if (writeStereoBufferPointer >= recordBuffer.Length)
+                        writeStereoBufferPointer = 0;
+
+                    bufferFrameOffset += frameCount;
+                    framesRemaining -= frameCount;
+
+                    bufferFillLevel += frameCount * 2;
                     if (bufferFillLevel > recordBuffer.Length)
                         bufferFillLevel = recordBuffer.Length;
                 }
@@ -104,7 +119,7 @@ namespace WDE.ReBuzzAudioIn
 			{
 				for (int i = 0; i < n; i++)
 				{
-					if (machineState.NumChannels == 1)
+					if (machineState.NumChannels == 0)
 					{
 						output[i].L = output[i].R = recordBuffer[readBufferPointer] * 32768.0f;
                         readBufferPointer++;
@@ -145,19 +160,22 @@ namespace WDE.ReBuzzAudioIn
 	
 		public class State : INotifyPropertyChanged
 		{
-			public State()
+            // Input stereo channel to capture from
+            public int Channel { get; set; }
+            public State()
 			{	
-				numChannels = 1;
+				numChannels = 0;
 				bufferSize = 1024;
-			}	// NOTE: parameterless constructor is required by the xml serializer
+			}   // NOTE: parameterless constructor is required by the xml serializer
 
-			int numChannels;
+            // Mono or stereo input. 1 = mono, 2 = stereo
+            int numChannels;
 			public int NumChannels
 			{
 				get { return numChannels; }
 				set
 				{
-					numChannels = value;
+					numChannels = Math.Min(1, Math.Max(0, value));
                     if (PropertyChanged != null) PropertyChanged(this, new PropertyChangedEventArgs("NumChannels"));
                 }
 			}
@@ -193,7 +211,28 @@ namespace WDE.ReBuzzAudioIn
 		{
 			get
 			{
-				yield return new MenuItemVM() 
+                var g = new MenuItemVM.Group();
+
+                yield return new MenuItemVM()
+                {
+                    Text = "Channel",
+                    Children = Enumerable.Range(0, 32).Select(i => new MenuItemVM()
+                    {
+                        Text = "" + i,
+                        IsCheckable = true,
+                        CheckGroup = g,
+                        StaysOpenOnClick = true,
+                        IsChecked = i == MachineState.Channel,
+                        CommandParameter = i,
+                        Command = new SimpleCommand()
+                        {
+                            CanExecuteDelegate = p => true,
+                            ExecuteDelegate = p => MachineState.Channel = (int)p
+                        }
+                    })
+                };
+
+                yield return new MenuItemVM() 
 				{ 
 					Text = "About...", 
 					Command = new SimpleCommand()
@@ -238,7 +277,7 @@ namespace WDE.ReBuzzAudioIn
 				if (machine != null)
 				{
 					audioInMachine = (ReBuzzAudioInMachine)machine.ManagedMachine;
-					cbChannles.SetBinding(ComboBox.SelectedItemProperty, new Binding("MachineState.NumChannels") { Source = audioInMachine, Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
+					cbChannles.SetBinding(ComboBox.SelectedIndexProperty, new Binding("MachineState.NumChannels") { Source = audioInMachine, Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
                     cbLatency.SetBinding(ComboBox.SelectedItemProperty, new Binding("MachineState.BufferSize") { Source = audioInMachine, Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
 
                     cbLatency.SelectedItem = audioInMachine.MachineState.BufferSize;
@@ -266,13 +305,13 @@ namespace WDE.ReBuzzAudioIn
 			mainGrid.RowDefinitions.Add(new RowDefinition());
 
 			TextBlock tb;
-            tb = new TextBlock() { Margin = new Thickness(0, 0, 0, 4), AllowDrop = false, Text="Channels" };
+            tb = new TextBlock() { Margin = new Thickness(0, 0, 0, 4), AllowDrop = false, Text="Input Type" };
             Grid.SetRow(tb, 0);
             mainGrid.Children.Add(tb);
 			
             cbChannles = new ComboBox() { Margin = new Thickness(0, 0, 0, 4), AllowDrop = false };
-			cbChannles.Items.Add(1);
-            cbChannles.Items.Add(2);
+			cbChannles.Items.Add("Mono");
+            cbChannles.Items.Add("Stereo");
 			Grid.SetColumn(cbChannles, 1);
             Grid.SetRow(cbChannles, 0);
             mainGrid.Children.Add(cbChannles);

--- a/ReBuzz/Audio/AudioEngine.cs
+++ b/ReBuzz/Audio/AudioEngine.cs
@@ -11,9 +11,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Threading;
 
@@ -133,23 +135,28 @@ namespace ReBuzz.Audio
             SampleRateIn = sampleRate;
         }
 
-        float[] asioBuffer = new float[1024 * 16 * 2];
+        float[] asioBuffer = new float[1024 * 16 * 32]; // supports up to 32 channels
         private void AsioDuplexAudioAvailable(AsioProcessBuffers b)
         {
-            // For now, input only from first two channels, but we can expand this later if needed.
-            if (b.InputChannelCount < 2)
+            int channels = b.InputChannelCount;
+            int frames = b.Frames;
+
+            if (channels <= 0 || frames <= 0)
                 return;
 
-            var inL = b.GetInput(0);
-            var inR = b.GetInput(1);
+            // Interleave all input channels into asioBuffer
             int j = 0;
-            for (int i = 0; i < b.Frames; i++)
+
+            for (int i = 0; i < frames; i++)
             {
-                asioBuffer[j++] = inL[i];
-                asioBuffer[j++] = inR[i];
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    asioBuffer[j++] = b.GetInput(ch)[i];
+                }
             }
 
-            buzzCore.AudioInputAvalable(asioBuffer, j);
+            // Pass interleaved multichannel buffer to Buzz
+            buzzCore.AudioInputAvalable(asioBuffer, frames, channels);
         }
 
         private void AsioDuplexOutput(AsioProcessBuffers b)
@@ -186,36 +193,6 @@ namespace ReBuzz.Audio
 
             CreateAudioOut(SelectedOutDevice.Name);
             Play();
-        }
-
-        readonly float[] audioInBuffer = new float[512];
-        private void WasapiCapture_DataAvailable(object sender, WaveInEventArgs e)
-        {
-            int bytesRemaining = e.BytesRecorded;
-            int srcByteOffset = 0;
-            while (bytesRemaining > 0)
-            {
-                int copyCountBytes = Math.Min(bytesRemaining, audioInBuffer.Length * 4);
-                Buffer.BlockCopy(e.Buffer, srcByteOffset, audioInBuffer, 0, copyCountBytes);
-                int floatBufferSamples = copyCountBytes >> 2;
-
-                if (audioInResampler != null)
-                {
-                    audioInResampler.FillBuffer(audioInBuffer, floatBufferSamples >> 1);    // Number of stereo samples
-                    int availableCount = Math.Min(audioInResampler.AvailableSamples(), audioInBuffer.Length >> 1);              // Available stereo samples
-                    if (availableCount > 0)
-                    {
-                        audioInResampler.GetSamples(audioInBuffer, 0, availableCount);
-                        buzzCore.AudioInputAvalable(audioInBuffer, availableCount << 1);
-                    }
-                }
-                else
-                {
-                    buzzCore.AudioInputAvalable(audioInBuffer, floatBufferSamples);
-                }
-                srcByteOffset += copyCountBytes;
-                bytesRemaining -= copyCountBytes;
-            }
         }
 
         public void CreateWasapiOut(string deviceName)
@@ -321,17 +298,18 @@ namespace ReBuzz.Audio
                     }
 
                     wasapiRecorder = recorderBuilder.Build();
-                    
-                    wasapiRecorder.DataAvailable += WasapiRecorder_DataAvailable;
-                    wasapiRecorder.StartRecording();
+
                     SelectedInDevice = new AudioInDevice() { Name = deviceName, Type = AudioOutType.Wasapi, WaveFormat = wasapiRecorder.WaveFormat };
 
                     // NAudio WASAPI input resampling if different from output
                     if (wasapiDeviceSamplerate != wasapiRecorder.WaveFormat.SampleRate)
                     {
                         audioInResampler = new RealTimeResampler();
-                        audioInResampler.Reset(wasapiDeviceSamplerate, SampleRateIn);
+                        audioInResampler.Reset(wasapiDeviceSamplerate, SampleRateIn, SelectedInDevice.WaveFormat.Channels);
                     }
+
+                    wasapiRecorder.DataAvailable += WasapiRecorder_DataAvailable;
+                    wasapiRecorder.StartRecording();
                 }
             }
             catch (Exception ex)
@@ -344,9 +322,46 @@ namespace ReBuzz.Audio
             SelectedOutDevice = new AudioOutDevice() { Name = deviceName, Type = AudioOutType.Wasapi, WavePlayer = wasapiPlayer };
         }
 
+        readonly float[] audioInBuffer = new float[512];
         private void WasapiRecorder_DataAvailable(ReadOnlySpan<byte> buffer, AudioClientBufferFlags flags, long devicePosition, long qpcPosition)
         {
-            WasapiCapture_DataAvailable(this, new WaveInEventArgs(buffer.ToArray(), buffer.Length));
+            int bytesRemaining = buffer.Length;
+            int srcByteOffset = 0;
+
+            int channels = SelectedInDevice.WaveFormat.Channels;
+
+            // Get a byte-span view over the float buffer
+            Span<byte> audioInBytes = MemoryMarshal.AsBytes(audioInBuffer.AsSpan());
+
+            while (bytesRemaining > 0)
+            {
+                int copyCountBytes = Math.Min(bytesRemaining, audioInBytes.Length);
+                // Copy from ReadOnlySpan<byte> → Span<byte>
+                buffer.Slice(srcByteOffset, copyCountBytes).CopyTo(audioInBytes);
+
+                int floatSamples = copyCountBytes / 4;      // total float samples
+                int frames = floatSamples / channels;       // audio frames
+
+                if (audioInResampler != null)
+                {
+                    audioInResampler.FillBuffer(audioInBuffer, frames);
+
+                    int availableFrames = Math.Min(audioInResampler.AvailableFrames(),
+                                                    audioInBuffer.Length / channels);
+
+                    if (availableFrames > 0)
+                    {
+                        audioInResampler.GetSamples(audioInBuffer, 0, availableFrames);
+                        buzzCore.AudioInputAvalable(audioInBuffer, availableFrames, channels);
+                    }
+                }
+                else
+                {
+                    buzzCore.AudioInputAvalable(audioInBuffer, frames, channels);
+                }
+                srcByteOffset += copyCountBytes;
+                bytesRemaining -= copyCountBytes;
+            }
         }
 
         bool InitWasapiOut(WasapiPlayer wasapiOut)

--- a/ReBuzz/Audio/RealTimeResampler.cs
+++ b/ReBuzz/Audio/RealTimeResampler.cs
@@ -1,30 +1,28 @@
-﻿using Buzz.MachineInterface;
-using System;
+﻿using System;
 using BuzzGUI.WaveformControl.r8brain;
 
 namespace ReBuzz.Audio
 {
-    public class RealTimeResampler
+    public class RealTimeResampler : IDisposable
     {
         public static int RT_BUFFER_SIZE = 1024;
         public static int DEST_BUFFER_SIZE = 2048;
 
-        R8brain r8bL = new R8brain();
-        R8brain r8bR = new R8brain();
-        float[] sourceData = new float[RT_BUFFER_SIZE];
-        double[] sourceDataDoubleL = new double[RT_BUFFER_SIZE];
-        double[] sourceDataDoubleR = new double[RT_BUFFER_SIZE];
-        int sourceDataFillLevel = 0;
+        private R8brain[] resamplers;
+        private float[] sourceData;
+        private double[][] sourceDataDouble;
 
-        bool inputReady;
+        private int sourceDataFillLevel = 0;
 
-        float[] destData = new float[DEST_BUFFER_SIZE * 2];
-        int destDataWritePos = 0;
-        int destDataReadPos = 0;
-        int destDataFilleLevel = 0;
+        private float[] destData;
+        private int destDataWritePos = 0;
+        private int destDataReadPos = 0;
+        private int destDataFillLevel = 0;
 
-        public int InputRate { get; set; }
-        public int OutputRate { get; set; }
+        public int InputRate { get; private set; }
+        public int OutputRate { get; private set; }
+        public int ChannelCount { get; private set; }
+
         public double BufferReminder { get; internal set; }
         public int ReadEndPos { get; internal set; }
 
@@ -32,170 +30,126 @@ namespace ReBuzz.Audio
         {
             InputRate = -1;
             OutputRate = -1;
+            ChannelCount = 2;
         }
 
-        public void Reset(int outputRate, int inputRate)
+        public void Reset(int outputRate, int inputRate, int channelCount)
         {
             Dispose();
 
-            InputRate = (int)inputRate;
-            OutputRate = (int)outputRate;
+            InputRate = inputRate;
+            OutputRate = outputRate;
+            ChannelCount = channelCount;
 
-            inputReady = false;
+            // Allocate per-channel resamplers
+            resamplers = new R8brain[channelCount];
+            sourceDataDouble = new double[channelCount][];
 
-            r8bL = new R8brain();
-            r8bL.Create(inputRate, outputRate, RT_BUFFER_SIZE, 2.0, ER8BResamplerRes.r8brr24);
+            for (int ch = 0; ch < channelCount; ch++)
+            {
+                resamplers[ch] = new R8brain();
+                resamplers[ch].Create(inputRate, outputRate, RT_BUFFER_SIZE, 2.0, ER8BResamplerRes.r8brr24);
 
-            r8bR = new R8brain();
-            r8bR.Create(inputRate, outputRate, RT_BUFFER_SIZE, 2.0, ER8BResamplerRes.r8brr24);
+                sourceDataDouble[ch] = new double[RT_BUFFER_SIZE];
+            }
 
-            Array.Clear(sourceData, 0, sourceData.Length);
+            // Interleaved input buffer
+            sourceData = new float[RT_BUFFER_SIZE * channelCount];
             sourceDataFillLevel = 0;
 
-            Array.Clear(destData, 0, destData.Length);
+            // Interleaved output ring buffer
+            destData = new float[DEST_BUFFER_SIZE * channelCount];
             destDataWritePos = 0;
             destDataReadPos = 0;
-            destDataFilleLevel = 0;
+            destDataFillLevel = 0;
         }
 
-        // count == stereo samples
-        public void FillBuffer(float[] buffer, int count)
+        /// <summary>
+        /// Fill input buffer with interleaved samples.
+        /// count = number of frames
+        /// buffer.Length = count * ChannelCount
+        /// </summary>
+        public void FillBuffer(float[] buffer, int frames)
         {
-            if (buffer == null || buffer.Length > RT_BUFFER_SIZE || buffer.Length == 0) // Nonsense
+            int samples = frames * ChannelCount;
+
+            if (buffer == null || buffer.Length < samples)
                 return;
 
-            Array.Copy(buffer, 0, sourceData, sourceDataFillLevel, count * 2);
-            sourceDataFillLevel += count * 2;
+            Array.Copy(buffer, 0, sourceData, sourceDataFillLevel, samples);
+            sourceDataFillLevel += samples;
 
-            int inputBufferFillLevel = Math.Min(RT_BUFFER_SIZE, sourceDataFillLevel);
+            int inputSamples = Math.Min(sourceDataFillLevel, RT_BUFFER_SIZE * ChannelCount);
+            int inputFrames = inputSamples / ChannelCount;
 
-            // Handle both channels
-            // First left
-            int outputLengthGeneratedL;
-            double[] outputDataDoubleL;
-
-            for (int i = 0; i < inputBufferFillLevel / 2; i++)
+            // De-interleave into per-channel double buffers
+            for (int ch = 0; ch < ChannelCount; ch++)
             {
-                sourceDataDoubleL[i] = sourceData[2 * i];
-            }
-
-            // Right
-            int outputLengthGeneratedR;
-            double[] outputDataDoubleR;
-
-            for (int i = 0; i < inputBufferFillLevel / 2; i++)
-            {
-                sourceDataDoubleR[i] = sourceData[2 * i + 1];
-            }
-
-            outputLengthGeneratedL = r8bL.Process(sourceDataDoubleL, inputBufferFillLevel / 2, out outputDataDoubleL);
-            outputLengthGeneratedR = r8bR.Process(sourceDataDoubleR, inputBufferFillLevel / 2, out outputDataDoubleR);
-
-            int dataPosL = destDataWritePos;
-            for (int i = 0; i < outputLengthGeneratedL; i++)
-            {
-                destData[dataPosL] = (float)outputDataDoubleL[i];
-                dataPosL += 2;
-                if (dataPosL >= destData.Length)
-                    dataPosL = 0;
-            }
-
-            int dataPosR = destDataWritePos + 1;
-            for (int i = 0; i < outputLengthGeneratedR; i++)
-            {
-                destData[dataPosR] = (float)outputDataDoubleR[i];
-                dataPosR += 2;
-                if (dataPosR >= destData.Length)
-                    dataPosR = 1;
-            }
-
-            sourceDataFillLevel -= inputBufferFillLevel;
-
-            destDataWritePos = (destDataWritePos + outputLengthGeneratedL * 2) % destData.Length;
-            destDataFilleLevel += outputLengthGeneratedL * 2;
-        }
-
-        internal void FillBuffer(Sample[] sampleDataTmp, int count)
-        {
-            float[] buf = new float[sampleDataTmp.Length * 2];
-            for (int i = 0; i < sampleDataTmp.Length; i++)
-            {
-                buf[i * 2] = sampleDataTmp[i].L;
-                buf[i * 2 + 1] = sampleDataTmp[i].R;
-            }
-
-            FillBuffer(buf, count);
-        }
-
-
-        public void GetSamples(Sample[] outbuffer, int num, float gainL, float gainR)
-        {
-            if (destDataWritePos / 2 >= num)
-            {
-                inputReady = true;
-            }
-            else
-            {
-                for (int i = 0; i < num; i++)
+                for (int f = 0; f < inputFrames; f++)
                 {
-                    outbuffer[i].L = 0;
-                    outbuffer[i].R = 0;
+                    sourceDataDouble[ch][f] = sourceData[f * ChannelCount + ch];
                 }
             }
 
-            if (inputReady && num <= destDataWritePos / 2)
+            // Process each channel
+            int outputFrames = 0;
+            double[][] outputDouble = new double[ChannelCount][];
+
+            for (int ch = 0; ch < ChannelCount; ch++)
             {
-                for (int i = 0; i < num; i++)
-                {
-                    outbuffer[i].L += destData[i * 2] * gainL;
-                    outbuffer[i].R += destData[i * 2 + 1] * gainR;
-                }
-                Array.Copy(destData, num * 2, destData, 0, destData.Length - num * 2);
-                destDataWritePos -= num * 2;
+                outputFrames = resamplers[ch].Process(
+                    sourceDataDouble[ch],
+                    inputFrames,
+                    out outputDouble[ch]
+                );
             }
+
+            // Interleave into destData ring buffer
+            int writePos = destDataWritePos;
+
+            for (int f = 0; f < outputFrames; f++)
+            {
+                for (int ch = 0; ch < ChannelCount; ch++)
+                {
+                    destData[writePos] = (float)outputDouble[ch][f];
+                    writePos++;
+
+                    if (writePos >= destData.Length)
+                        writePos = 0;
+                }
+            }
+
+            destDataWritePos = writePos;
+            destDataFillLevel += outputFrames * ChannelCount;
+
+            sourceDataFillLevel -= inputSamples;
         }
 
-        public void GetSamples(float[] outbuffer, int offset, int num)
+        public void GetSamples(float[] outbuffer, int offset, int frames)
         {
-            int bufferCount = num * 2;
+            int samplesNeeded = frames * ChannelCount;
 
-            // Ensure there is data available
-            if (destDataFilleLevel >= bufferCount)
+            if (destDataFillLevel < samplesNeeded)
             {
-                inputReady = true;
-            }
-            else
-            {
-                for (int i = 0; i < bufferCount; i++)
-                {
-                    outbuffer[i] = 0;
-                }
+                Array.Clear(outbuffer, offset, samplesNeeded);
+                return;
             }
 
-            if (inputReady)
+            for (int i = 0; i < samplesNeeded; i++)
             {
-                for (int i = 0; i < bufferCount; i++)
-                {
-                    outbuffer[i] = destData[destDataReadPos];
-                    destDataReadPos++;
-                    if (destDataReadPos >= destData.Length)
-                        destDataReadPos = 0;
-                }
-                destDataFilleLevel -= bufferCount;
+                outbuffer[offset + i] = destData[destDataReadPos];
+                destDataReadPos++;
+
+                if (destDataReadPos >= destData.Length)
+                    destDataReadPos = 0;
             }
+
+            destDataFillLevel -= samplesNeeded;
         }
 
-        public void Dispose()
+        public void FillSilenceInSamples(int numSamples)
         {
-            if (r8bL != null)
-                r8bL.Dispose();
-            if (r8bR != null)
-                r8bR.Dispose();
-        }
-
-        internal void FillSilenceInSamples(int numSamples)
-        {
-            float[] buffer = new float[2 * numSamples];
+            float[] buffer = new float[numSamples * ChannelCount];
             FillBuffer(buffer, numSamples);
         }
 
@@ -203,18 +157,29 @@ namespace ReBuzz.Audio
         {
             sourceDataFillLevel = 0;
             destDataWritePos = 0;
-            r8bL.Clear();
-            r8bR.Clear();
+            destDataReadPos = 0;
+
+            foreach (var r in resamplers)
+                r?.Clear();
         }
 
-        internal bool IsDirty()
+        public bool IsDirty()
         {
             return (sourceDataFillLevel > 0 || destDataWritePos > 0);
         }
 
-        internal int AvailableSamples()
+        public int AvailableFrames()
         {
-            return destDataFilleLevel >> 1;
+            return destDataFillLevel / ChannelCount;
+        }
+
+        public void Dispose()
+        {
+            if (resamplers != null)
+            {
+                foreach (var r in resamplers)
+                    r.Dispose();
+            }
         }
     }
 }

--- a/ReBuzz/Core/ReBuzzCore.cs
+++ b/ReBuzz/Core/ReBuzzCore.cs
@@ -180,6 +180,7 @@ namespace ReBuzz.Core
         internal DispatcherTimer dtEngineThread;
 
         public int OutputChannels { get => AudioEngine.GetAudioProvider().AudioSampleProvider.OutputChannels; }
+        public int InputChannels { get => AudioEngine.SelectedInDevice != null ? AudioEngine.SelectedInDevice.WaveFormat.Channels : 0; }
 
         int speed;
         bool playing;
@@ -2247,10 +2248,10 @@ namespace ReBuzz.Core
             }
         }
 
-        public event Action<float[], int> AudioReceived;
-        internal void AudioInputAvalable(float[] samples, int n)
+        public event Action<float[], int, int> AudioReceived;
+        internal void AudioInputAvalable(float[] samples, int frames, int channels)
         {
-            AudioReceived?.Invoke(samples, n);
+            AudioReceived?.Invoke(samples, frames, channels);
         }
 
         Lock audioOutLock = new();

--- a/ReBuzz/Core/WavetableCore.cs
+++ b/ReBuzz/Core/WavetableCore.cs
@@ -262,7 +262,7 @@ namespace ReBuzz.Core
                         looptype = looptype,
                         layer = layer
                     };
-                    realTimeResampler.Reset(Global.Buzz.SelectedAudioDriverSampleRate, wave.Layers[layer].SampleRate <= 0 ? 44100 : wave.Layers[layer].SampleRate);
+                    realTimeResampler.Reset(Global.Buzz.SelectedAudioDriverSampleRate, wave.Layers[layer].SampleRate <= 0 ? 44100 : wave.Layers[layer].SampleRate, wave.Layers[layer].ChannelCount);
                 }
                 catch (Exception e)
                 {
@@ -287,7 +287,7 @@ namespace ReBuzz.Core
                         looptype = LoopType.None,
                         sf = sf
                     };
-                    realTimeResampler.Reset(Global.Buzz.SelectedAudioDriverSampleRate, sf.SampleRate);
+                    realTimeResampler.Reset(Global.Buzz.SelectedAudioDriverSampleRate, sf.SampleRate, sf.ChannelCount);
                 }
                 catch (Exception e)
                 {
@@ -323,7 +323,7 @@ namespace ReBuzz.Core
                     if (PlayWaveData.sf != null)
                     {
                         int samplesRead = 0;
-                        while (realTimeResampler.AvailableSamples() < sampleCount)
+                        while (realTimeResampler.AvailableFrames() < sampleCount)
                         {
                             if (!ReadSamplesFromFile(offset, sampleCount))
                                 return false;
@@ -336,7 +336,7 @@ namespace ReBuzz.Core
                     else if (PlayWaveData.wave.Layers.Count > 0)
                     {
                         var layer = PlayWaveData.wave.Layers[PlayWaveData.layer];
-                        while (realTimeResampler.AvailableSamples() < sampleCount)
+                        while (realTimeResampler.AvailableFrames() < sampleCount)
                         {
                             layer.GetDataAsFloat(wavetableAudiobuffer, 0, 2, 0, PlayWaveData.postion, sampleCount);
                             layer.GetDataAsFloat(wavetableAudiobuffer, 0 + 1, 2, 1, PlayWaveData.postion, sampleCount);

--- a/ReBuzzGUI/BuzzGUI.Interfaces/IBuzz.cs
+++ b/ReBuzzGUI/BuzzGUI.Interfaces/IBuzz.cs
@@ -113,11 +113,13 @@ namespace BuzzGUI.Interfaces
 
         // Audio interface outputs.
         public int OutputChannels { get; }
-
+        public int InputChannels { get; }
         // Extensions
         void SetModifiedFlag();
         // void ControlChange(IMachine machine, int group, int track, int param, int value);
-        event Action<float[], int> AudioReceived;
+
+        // Buffer, frames, channel count
+        event Action<float[], int, int> AudioReceived;
         void AudioOut(int channel, Sample[] samples, int n);
 
         // Device number, device name


### PR DESCRIPTION
Enable multi‑channel audio input

This PR adds support for multi‑channel ASIO/WASAPI input and routing using ReBuzz Audio In. Instead of being limited to a fixed stereo pair, you can now select which stereo channel pair to capture from the incoming multi‑channel audio stream.

Usage

1. Add ReBuzz Audio In to your project.
2. Connect it to your effects chain or master.
3. Select the desired audio input channel pair from the ReBuzz Audio In menu (each entry corresponds to a stereo pair: L/R).

This makes it possible to use multiple input channels (e.g. external synths, hardware inputs, multi‑mic setups) and route them flexibly inside ReBuzz.